### PR TITLE
Swift 6 Support

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -28,7 +28,7 @@ let package = Package(
             name: "AsyncSequenceReader",
             dependencies: [],
             swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency"),
+                .swiftLanguageVersion(.v6),
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please check the [releases](https://github.com/mochidev/AsyncSequenceReader/rele
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/mochidev/AsyncSequenceReader.git", .upToNextMinor(from: "0.2.2")),
+    .package(url: "https://github.com/mochidev/AsyncSequenceReader.git", .upToNextMinor(from: "0.3.0")),
 ],
 ...
 targets: [

--- a/Sources/AsyncSequenceReader/AsyncReadSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadSequence.swift
@@ -29,7 +29,7 @@ extension AsyncIteratorProtocol {
     public mutating func transform<Transformed, ReadSequence: AsyncReadSequence>(
         with sequenceTransform: (ReadSequence) async throws -> Transformed,
         readSequenceFactory: (inout AsyncBufferedIterator<Self>) -> ReadSequence
-    ) async rethrows -> Transformed? where ReadSequence.BaseIterator == Self {
+    ) async throws -> Transformed? where ReadSequence.BaseIterator == Self {
         var results: Transformed? = nil
         var wrappedIterator = AsyncBufferedIterator(self)
         if try await wrappedIterator.hasMoreData() {
@@ -54,7 +54,7 @@ extension AsyncBufferedIterator {
     public mutating func transform<Transformed, ReadSequence: AsyncReadSequence>(
         with sequenceTransform: (ReadSequence) async throws -> Transformed,
         readSequenceFactory: (inout Self) -> ReadSequence
-    ) async rethrows -> Transformed? where ReadSequence.BaseIterator == BaseIterator {
+    ) async throws -> Transformed? where ReadSequence.BaseIterator == BaseIterator {
         
         var results: Transformed? = nil
         if try await self.hasMoreData() {

--- a/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
@@ -82,7 +82,7 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         _ count: Int,
         sequenceTransform: (AsyncReadUpToCountSequence<Self>) async throws -> Transformed
-    ) async rethrows -> Transformed? {
+    ) async throws -> Transformed? {
         assert(count >= 0, "count must be larger than 0")
         return try await collect(min: count, max: count, sequenceTransform: sequenceTransform)
     }
@@ -121,7 +121,7 @@ extension AsyncIteratorProtocol {
         min minCount: Int = 0,
         max maxCount: Int,
         sequenceTransform: (AsyncReadUpToCountSequence<Self>) async throws -> Transformed
-    ) async rethrows -> Transformed? {
+    ) async throws -> Transformed? {
         try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
     }
 }
@@ -159,7 +159,7 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         _ count: Int,
         sequenceTransform: (AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
-    ) async rethrows -> Transformed? {
+    ) async throws -> Transformed? {
         assert(count >= 0, "count must be larger than 0")
         return try await collect(min: count, max: count, sequenceTransform: sequenceTransform)
     }
@@ -198,7 +198,7 @@ extension AsyncBufferedIterator {
         min minCount: Int = 0,
         max maxCount: Int,
         sequenceTransform: (AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
-    ) async rethrows -> Transformed? {
+    ) async throws -> Transformed? {
         try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
     }
 }

--- a/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
@@ -184,8 +184,8 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
-    ) async -> Transformed? where Element: Equatable {
-        await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
+    ) async throws -> Transformed? where Element: Equatable {
+        try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
@@ -221,8 +221,8 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
-    ) async -> Transformed? where Element: Equatable {
-        await transform(with: sequenceTransform) { .init($0, termination: termination) }
+    ) async throws -> Transformed? where Element: Equatable {
+        try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
@@ -258,7 +258,7 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
-    ) async rethrows -> Transformed? where Element: Equatable {
+    ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
@@ -295,7 +295,7 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
-    ) async rethrows -> Transformed? where Element: Equatable {
+    ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
 }
@@ -335,8 +335,8 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
-    ) async -> Transformed? where Element: Equatable {
-        await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
+    ) async throws -> Transformed? where Element: Equatable {
+        try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
@@ -372,8 +372,8 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
         sequenceTransform: (AsyncReadUpToElementsSequence<BaseIterator>) async -> Transformed
-    ) async -> Transformed? where Element: Equatable {
-        await transform(with: sequenceTransform) { .init($0, termination: termination) }
+    ) async throws -> Transformed? where Element: Equatable {
+        try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
@@ -409,7 +409,7 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
         sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
-    ) async rethrows -> Transformed? where Element: Equatable {
+    ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
@@ -446,7 +446,7 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
         sequenceTransform: (AsyncReadUpToElementsSequence<BaseIterator>) async throws -> Transformed
-    ) async rethrows -> Transformed? where Element: Equatable {
+    ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
 }

--- a/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
@@ -16,7 +16,7 @@ final class AsyncReadUpToElementsSequenceTests: XCTestCase {
         let testStream = TestSequence(base: "apple orange banana kiwi kumquat pear pineapple")
         
         let results = testStream.iteratorMap { iterator -> String? in
-            let word = await iterator.collect(upToIncluding: " ") { sequence -> String in
+            let word = try await iterator.collect(upToIncluding: " ") { sequence -> String in
                 await sequence.reduce(into: "") { $0.append($1) }
             }
             
@@ -28,13 +28,13 @@ final class AsyncReadUpToElementsSequenceTests: XCTestCase {
         
         var resultsIterator = results.makeAsyncIterator()
         
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "apple")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "orange")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "banana")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "kiwi")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "kumquat")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "pear")
-        await AsyncXCTAssertEqual(await resultsIterator.next(), "pineapple")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "apple")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "orange")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "banana")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "kiwi")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "kumquat")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "pear")
+        try await AsyncXCTAssertEqual(await resultsIterator.next(), "pineapple")
     }
     
     func testIteratorMapUpToIncluding() async throws {


### PR DESCRIPTION
Added support for Swift 6. Note that this makes some previously non-throwing methods throwing to properly conform to incorrect assumptions.