### PR TITLE
Proper Swift 6 Support

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Mark Workspace As Safe

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -5,6 +5,10 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
 jobs:
   API-Check:
     name: Diagnose API Breaking Changes

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
     - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   Build-Release-6-0:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,151 @@
+name: Swift Version Compatibility
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  Build-Release-6-0:
+    name: Build Swift 6.0 Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.0"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration release
+
+  Build-Debug-6-0:
+    name: Build Swift 6.0 Debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.0"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration debug
+
+  Build-Release-6-1:
+    name: Build Swift 6.1 Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.1"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration release
+
+  Build-Debug-6-1:
+    name: Build Swift 6.1 Debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.1"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration debug
+
+  Build-Release-6-2:
+    name: Build Swift 6.2 Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.2"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration release
+
+  Build-Debug-6-2:
+    name: Build Swift 6.2 Debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.2"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration debug
+
+  Build-Release-6-3:
+    name: Build Swift 6.3 Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.3"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration release
+
+  Build-Debug-6-3:
+    name: Build Swift 6.3 Debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v6
+    - name: Set Swift Version
+      uses: vapor/swiftly-action@v0.2
+      with:
+        toolchain: "6.3"
+    - name: Swift Version
+      run: |
+        swift --version
+    - name: Build
+      run: |
+        swift build --configuration debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
     - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   Test-Release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
+    - name: Swift Version
+      run: |
+        swift --version
     - name: Build
       run: |
-        swift build --build-tests --configuration release -Xswiftc -enable-testing -Xswiftc -warnings-as-errors -Xcc -Werror
+        swift build --build-tests --configuration release -Xswiftc -enable-testing -Xswiftc -warnings-as-errors
     - name: Run Tests
       run: |
         swift test --skip-build --configuration release
@@ -24,10 +27,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
+    - name: Swift Version
+      run: |
+        swift --version
     - name: Build
       run: |
-        swift build --build-tests --configuration debug -Xswiftc -enable-testing -Xswiftc -warnings-as-errors -Xcc -Werror
+        swift build --build-tests --configuration debug -Xswiftc -enable-testing -Xswiftc -warnings-as-errors
     - name: Run Tests
       run: |
         swift test --skip-build --configuration debug

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@
 import PackageDescription
 
 let swiftSettings: [PackageDescription.SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InferIsolatedConformances"),

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,10 @@
 import PackageDescription
 
 let swiftSettings: [PackageDescription.SwiftSetting] = [
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),
 ]
 

--- a/Sources/AsyncSequenceReader/AnyReadableSequence.swift
+++ b/Sources/AsyncSequenceReader/AnyReadableSequence.swift
@@ -9,14 +9,14 @@
 /// A type-erased convenience type to normalize synchronous and asynchronous sequences into a common async type.
 public struct AnyReadableSequence<Element>: AsyncSequence {
     @usableFromInline
-    let makeUnderlyingIterator: @Sendable () -> () async throws -> Element?
+    let makeUnderlyingIterator: @Sendable () -> @Sendable () async throws -> Element?
     
     public struct AsyncIterator: AsyncIteratorProtocol {
         @usableFromInline
-        let makeUnderlyingNext: () async throws -> Element?
+        let makeUnderlyingNext: @Sendable () async throws -> Element?
         
         @inlinable
-        init(_ makeUnderlyingNext: @escaping () async throws -> Element?) {
+        init(_ makeUnderlyingNext: @Sendable @escaping () async throws -> Element?) {
             self.makeUnderlyingNext = makeUnderlyingNext
         }
         
@@ -32,7 +32,7 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
     }
     
     @inlinable
-    init(_ makeUnderlyingIterator: @Sendable @escaping () -> () async throws -> Element?) {
+    init(_ makeUnderlyingIterator: @Sendable @escaping () -> @Sendable () async throws -> Element?) {
         self.makeUnderlyingIterator = makeUnderlyingIterator
     }
     
@@ -40,7 +40,7 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
     @inlinable
     public init<S: Sequence & Sendable>(_ sequence: S) where S.Element == Element, Element: Sendable {
         self.init {
-            var iterator = sequence.makeIterator()
+            nonisolated(unsafe) var iterator = sequence.makeIterator()
             
             return { iterator.next() }
         }
@@ -50,7 +50,7 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
     @inlinable
     public init<S: AsyncSequence & Sendable>(_ sequence: S) where S.Element == Element, Element: Sendable {
         self.init {
-            var iterator = sequence.makeAsyncIterator()
+            nonisolated(unsafe) var iterator = sequence.makeAsyncIterator()
             
             return { try await iterator.next() }
         }
@@ -58,4 +58,4 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
 }
 
 extension AnyReadableSequence: Sendable where Element: Sendable {}
-extension AnyReadableSequence.AsyncIterator: @unchecked Sendable where Element: Sendable {}
+extension AnyReadableSequence.AsyncIterator: Sendable where Element: Sendable {}

--- a/Sources/AsyncSequenceReader/AsyncBufferedIterator.swift
+++ b/Sources/AsyncSequenceReader/AsyncBufferedIterator.swift
@@ -9,7 +9,7 @@
 /// An iterator that wraps and can buffer another iterator, allowing safe reading ahead.
 public struct AsyncBufferedIterator<BaseIterator: AsyncIteratorProtocol>: AsyncIteratorProtocol {
     @usableFromInline
-    var baseIterator: BaseIterator
+    nonisolated(unsafe) var baseIterator: BaseIterator
     
     /// The unconsumed buffer, including all reads that have been made before the user specifically requested them.
     ///
@@ -23,19 +23,25 @@ public struct AsyncBufferedIterator<BaseIterator: AsyncIteratorProtocol>: AsyncI
     }
     
     @inlinable
+    @_disfavoredOverload
     public mutating func next() async rethrows -> BaseIterator.Element? {
+        try await next()
+    }
+    
+    @inlinable
+    public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> BaseIterator.Element? {
         guard unconsumedBuffer.isEmpty else {
             return unconsumedBuffer.removeFirst()
         }
         
-        return try await baseIterator.next()
+        return try await baseIterator._nextIsolated()
     }
     
     /// Read ahead, and store the value for later, or throw if the base iterator also throws.
     /// - Returns: The read-ahead value.
     @usableFromInline
-    mutating func nextUnconsumed() async rethrows -> BaseIterator.Element? {
-        let next = try await baseIterator.next()
+    mutating func nextUnconsumed(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> BaseIterator.Element? {
+        let next = try await baseIterator._nextIsolated()
         if let value = next {
             unconsumedBuffer.append(value)
         }
@@ -48,7 +54,7 @@ public struct AsyncBufferedIterator<BaseIterator: AsyncIteratorProtocol>: AsyncI
     /// If it does, the iterator saves the elements, and will deliver them immediately on the next call to `next()`
     /// - Returns: A Bool indicating if there is more to consume or not.
     @inlinable
-    public mutating func hasMoreData() async rethrows -> Bool {
+    public mutating func hasMoreData(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> Bool {
         guard unconsumedBuffer.isEmpty else {
             return true
         }
@@ -57,4 +63,4 @@ public struct AsyncBufferedIterator<BaseIterator: AsyncIteratorProtocol>: AsyncI
     }
 }
 
-extension AsyncBufferedIterator: Sendable where BaseIterator: Sendable, BaseIterator.Element: Sendable {}
+extension AsyncBufferedIterator: Sendable where BaseIterator.Element: Sendable {}

--- a/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
@@ -40,7 +40,7 @@ extension AsyncSequence {
     /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early.
     /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
     @inlinable
-    public func iteratorMap<Transformed>(_ transform: @Sendable @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async -> Transformed) -> AsyncIteratorMapSequence<Self, Transformed> {
+    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async -> Transformed) -> AsyncIteratorMapSequence<Self, Transformed> {
         AsyncIteratorMapSequence(self, transform: transform)
     }
     
@@ -83,7 +83,7 @@ extension AsyncSequence {
     /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early, as will throwing an error.
     /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
     @inlinable
-    public func iteratorMap<Transformed>(_ transform: @Sendable @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async throws -> Transformed) -> AsyncThrowingIteratorMapSequence<Self, Transformed> {
+    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async throws -> Transformed) -> AsyncThrowingIteratorMapSequence<Self, Transformed> {
         AsyncThrowingIteratorMapSequence(self, transform: transform)
     }
 }
@@ -94,12 +94,12 @@ public struct AsyncIteratorMapSequence<Base: AsyncSequence, Transformed> {
     let base: Base
     
     @usableFromInline
-    let transform: @Sendable (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+    nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
     
     @usableFromInline
     init(
         _ base: Base,
-        transform: @Sendable @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+        transform: @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
     ) {
         self.base = base
         self.transform = transform
@@ -117,12 +117,12 @@ extension AsyncIteratorMapSequence: AsyncSequence {
         @usableFromInline
         var baseIterator: AsyncBufferedIterator<Base.AsyncIterator>
         @usableFromInline
-        let transform: @Sendable (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+        nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
         
         @usableFromInline
         init(
             _ baseIterator: AsyncBufferedIterator<Base.AsyncIterator>,
-            transform: @Sendable @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+            transform: @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
         ) {
             self.baseIterator = baseIterator
             self.transform = transform
@@ -154,12 +154,12 @@ public struct AsyncThrowingIteratorMapSequence<Base, Transformed> where Base : A
     let base: Base
     
     @usableFromInline
-    let transform: @Sendable (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
+    nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
     
     @usableFromInline
     init(
         _ base: Base,
-        transform: @Sendable @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
+        transform: @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
     ) {
         self.base = base
         self.transform = transform
@@ -174,7 +174,7 @@ extension AsyncThrowingIteratorMapSequence: AsyncSequence {
         var baseIterator: AsyncBufferedIterator<Base.AsyncIterator>
         
         @usableFromInline
-        let transform: @Sendable (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
+        nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
         
         @usableFromInline
         var encounteredError = false
@@ -182,7 +182,7 @@ extension AsyncThrowingIteratorMapSequence: AsyncSequence {
         @usableFromInline
         init(
             _ baseIterator: AsyncBufferedIterator<Base.AsyncIterator>,
-            transform: @Sendable @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
+            transform: @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
         ) {
             self.baseIterator = baseIterator
             self.transform = transform

--- a/Sources/AsyncSequenceReader/AsyncIteratorProtocol+Isolated.swift
+++ b/Sources/AsyncSequenceReader/AsyncIteratorProtocol+Isolated.swift
@@ -1,0 +1,35 @@
+//
+//  AsyncIteratorProtocol+Isolated.swift
+//  AsyncSequenceReader
+//
+//  Created by Dimitri Bouniol on 2026-04-26.
+//  Copyright © 2021-24 Mochi Development, Inc. All rights reserved.
+//
+
+extension AsyncIteratorProtocol {
+    /// Internal method for getting the next value in an isolated context.
+    @usableFromInline
+    mutating func _nextIsolated(_ actor: isolated (any Actor)? = #isolation) async rethrows -> Element? {
+        if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+            return try await self.next(isolation: actor)
+        } else {
+            nonisolated(unsafe) var iterator = self
+            defer { self = iterator }
+            #if compiler(>=6.2)
+            return try await iterator.next()
+            #else
+            /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable result type 'Self.Element?' cannot be sent from nonisolated context in call to instance method 'next()'`
+            let value = try await iterator._nextSendable()
+            return value as! Element?
+            #endif
+        }
+    }
+    
+    #if compiler(<6.2)
+    /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable result type 'Self.Element?' cannot be sent from nonisolated context in call to instance method 'next()'`
+    @usableFromInline
+    mutating func _nextSendable() async rethrows -> sending Any {
+        try await self.next() as Any
+    }
+    #endif
+}

--- a/Sources/AsyncSequenceReader/AsyncReadSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadSequence.swift
@@ -25,13 +25,13 @@ extension AsyncIteratorProtocol {
     /// - Parameter readSequenceFactory: A factory to create a suitable ``AsyncReadSequence`` that will determine the logical bounds of the transformation within the receiving iterator.
     /// - Returns: A transformed value read from the iterator, or `nil` if there were no values left to read.
     public mutating func transform<Transformed, ReadSequence: AsyncReadSequence>(
-        with sequenceTransform: (ReadSequence) async throws -> Transformed,
+        with sequenceTransform: sending (sending ReadSequence) async throws -> Transformed,
         readSequenceFactory: (inout AsyncBufferedIterator<Self>) -> ReadSequence
     ) async throws -> Transformed? where ReadSequence.BaseIterator == Self {
         var results: Transformed? = nil
         var wrappedIterator = AsyncBufferedIterator(self)
         if try await wrappedIterator.hasMoreData() {
-            let readSequence = readSequenceFactory(&wrappedIterator)
+            nonisolated(unsafe) let readSequence = readSequenceFactory(&wrappedIterator)
             results = try await sequenceTransform(readSequence)
             wrappedIterator = readSequence.baseIterator
         }
@@ -50,13 +50,12 @@ extension AsyncBufferedIterator {
     /// - Parameter readSequenceFactory: A factory to create a suitable ``AsyncReadSequence`` that will determine the logical bounds of the transformation within the receiving iterator.
     /// - Returns: A transformed value read from the iterator, or `nil` if there were no values left to read.
     public mutating func transform<Transformed, ReadSequence: AsyncReadSequence>(
-        with sequenceTransform: (ReadSequence) async throws -> Transformed,
+        with sequenceTransform: sending (sending ReadSequence) async throws -> Transformed,
         readSequenceFactory: (inout Self) -> ReadSequence
     ) async throws -> Transformed? where ReadSequence.BaseIterator == BaseIterator {
-        
         var results: Transformed? = nil
         if try await self.hasMoreData() {
-            let readSequence = readSequenceFactory(&self)
+            nonisolated(unsafe) let readSequence = readSequenceFactory(&self)
             results = try await sequenceTransform(readSequence)
             self = readSequence.baseIterator
         }

--- a/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
@@ -31,7 +31,7 @@ extension AsyncIteratorProtocol {
         var result = [Element]()
         result.reserveCapacity(minCount)
         
-        while let next = try await next() {
+        while let next = try await _nextIsolated() {
             result.append(next)
             
             if result.count == maxCount {
@@ -79,7 +79,7 @@ extension AsyncIteratorProtocol {
     /// - Throws: `AsyncSequenceReaderError.insufficientElements` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect<Transformed>(
         _ count: Int,
-        sequenceTransform: (AsyncReadUpToCountSequence<Self>) async throws -> Transformed
+        sequenceTransform: sending (sending AsyncReadUpToCountSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? {
         assert(count >= 0, "count must be larger than 0")
         return try await collect(min: count, max: count, sequenceTransform: sequenceTransform)
@@ -118,7 +118,7 @@ extension AsyncIteratorProtocol {
     public mutating func collect<Transformed>(
         min minCount: Int = 0,
         max maxCount: Int,
-        sequenceTransform: (AsyncReadUpToCountSequence<Self>) async throws -> Transformed
+        sequenceTransform: sending (sending AsyncReadUpToCountSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? {
         try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
     }
@@ -156,7 +156,7 @@ extension AsyncBufferedIterator {
     /// - Throws: `AsyncSequenceReaderError.insufficientElements` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect<Transformed>(
         _ count: Int,
-        sequenceTransform: (AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
+        sequenceTransform: sending (sending AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
     ) async throws -> Transformed? {
         assert(count >= 0, "count must be larger than 0")
         return try await collect(min: count, max: count, sequenceTransform: sequenceTransform)
@@ -195,7 +195,7 @@ extension AsyncBufferedIterator {
     public mutating func collect<Transformed>(
         min minCount: Int = 0,
         max maxCount: Int,
-        sequenceTransform: (AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
+        sequenceTransform: sending (sending AsyncReadUpToCountSequence<BaseIterator>) async throws -> Transformed
     ) async throws -> Transformed? {
         try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
     }

--- a/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
@@ -70,7 +70,7 @@ extension AsyncIteratorProtocol {
         precondition(!termination.isEmpty, "stopSequence must not be empty")
         var result = [Element]()
         
-        while let next = try await next() {
+        while let next = try await _nextIsolated() {
             if result.count == maximumBufferSize {
                 throw AsyncSequenceReaderError.terminationNotFound(maximum: maximumBufferSize, actual: result.count)
             }
@@ -181,7 +181,7 @@ extension AsyncIteratorProtocol {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
@@ -218,7 +218,7 @@ extension AsyncIteratorProtocol {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
@@ -255,7 +255,7 @@ extension AsyncIteratorProtocol {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
@@ -292,7 +292,7 @@ extension AsyncIteratorProtocol {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
@@ -332,7 +332,7 @@ extension AsyncBufferedIterator {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
@@ -369,7 +369,7 @@ extension AsyncBufferedIterator {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
-        sequenceTransform: (AsyncReadUpToElementsSequence<BaseIterator>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<BaseIterator>) async -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
@@ -406,7 +406,7 @@ extension AsyncBufferedIterator {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
@@ -443,7 +443,7 @@ extension AsyncBufferedIterator {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: [Element],
-        sequenceTransform: (AsyncReadUpToElementsSequence<BaseIterator>) async throws -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<BaseIterator>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }

--- a/Sources/AsyncSequenceReader/AsyncSequenceReaderError.swift
+++ b/Sources/AsyncSequenceReader/AsyncSequenceReaderError.swift
@@ -21,7 +21,7 @@ public struct AsyncSequenceReaderError: Error, Hashable, Sendable {
         "AsyncSequenceReaderError.\(String(describing: code))"
     }
     
-    static func ~= (lhs: Self, rhs: Error) -> Bool {
+    static func ~= (lhs: Self, rhs: any Error) -> Bool {
         lhs == rhs as? AsyncSequenceReaderError
     }
 }

--- a/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
@@ -17,7 +17,7 @@ final class AsyncReadUpToElementsSequenceTests: XCTestCase, @unchecked Sendable 
         
         let results = testStream.iteratorMap { iterator -> String? in
             let word = try await iterator.collect(upToIncluding: " ") { sequence -> String in
-                await sequence.reduce(into: "") { $0.append($1) }
+                try await sequence.reduce(into: "") { $0.append($1) }
             }
             
             if let word = word, word.hasSuffix(" ") {

--- a/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderTests.swift
@@ -145,7 +145,7 @@ final class AsyncSequenceReaderTests: XCTestCase, @unchecked Sendable {
     
     // MARK: - Test Transforms
     
-    func countCharacters<ReadSequence: AsyncReadSequence>(_ sequence: ReadSequence) async throws -> Int? where ReadSequence.Element == String {
+    func countCharacters<ReadSequence: AsyncReadSequence>(_ sequence: sending ReadSequence) async throws -> Int? where ReadSequence.Element == String {
         try await sequence.map { $0.count }.reduce(into: 0) { partialResult, next in
             partialResult += next
         }

--- a/Tests/AsyncSequenceReaderTests/TestSequence.swift
+++ b/Tests/AsyncSequenceReaderTests/TestSequence.swift
@@ -45,9 +45,6 @@ struct ThrowingTestSequence<Base>: AsyncSequence where Base: Sequence {
     }
 }
 
-func AsyncXCTAssertEqual<T>(_ expression1: @autoclosure () async throws -> T, _ expression2: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async rethrows where T : Equatable {
-    let result1 = try await expression1()
-    let result2 = try await expression2()
-    
+func AsyncXCTAssertEqual<T>(_ result1: T, _ result2: T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async where T : Equatable {
     XCTAssertEqual(result1, result2, message(), file: file, line: line)
 }


### PR DESCRIPTION
- Fixed Sendable annotations for `AnyReadableSequence`
- Added helper to `AsyncIteratorProtocol` to always use the isolated variant of `next()`
- Updated package to infer isolated conformances and `nonisolated(nonsending)` by default
- Updated package to use existential any by default
- Updated workflows to latest recommended versions
- Added a Swift version compatibility workflow
- Updated workflows to not run concurrently in PRs