### PR TITLE
Preconditions and Test Coverage

### DIFF
--- a/Sources/AsyncSequenceReader/AnyReadableSequence.swift
+++ b/Sources/AsyncSequenceReader/AnyReadableSequence.swift
@@ -39,7 +39,7 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
     
     /// Initialize ``AnyReadableSequence`` with a sequence.
     @inlinable
-    public init<S: Sequence & Sendable>(_ sequence: S) where S.Element == Element, Element: Sendable {
+    public init<S: Sequence & Sendable>(_ sequence: S) where S.Element == Element {
         self.init {
             nonisolated(unsafe) var iterator = sequence.makeIterator()
             
@@ -49,7 +49,7 @@ public struct AnyReadableSequence<Element>: AsyncSequence {
     
     /// Initialize ``AnyReadableSequence`` with an async sequence.
     @inlinable
-    public init<S: AsyncSequence & Sendable>(_ sequence: S) where S.Element == Element, Element: Sendable {
+    public init<S: AsyncSequence & Sendable>(_ sequence: S) where S.Element == Element {
         self.init {
             nonisolated(unsafe) var iterator = sequence.makeAsyncIterator()
             

--- a/Sources/AsyncSequenceReader/AnyReadableSequence.swift
+++ b/Sources/AsyncSequenceReader/AnyReadableSequence.swift
@@ -8,6 +8,8 @@
 //
 
 /// A type-erased convenience type to normalize synchronous and asynchronous sequences into a common async type.
+///
+/// - Note: `AnyReadableSequence` supports being iterated multiple times _only_ if the underlying sequence supports being iterated multiple times.
 public struct AnyReadableSequence<Element>: AsyncSequence {
     @usableFromInline
     let makeUnderlyingIterator: @Sendable () -> @Sendable () async throws -> Element?

--- a/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
@@ -89,6 +89,88 @@ extension AsyncSequence {
     }
 }
 
+extension Sequence where Self: Sendable {
+    /// Creates an asynchronous sequence that maps the given closure over an iterator for the sequence, which can itself accept multiple reads.
+    ///
+    /// When finished reading from the iterator, return your completed object, and the closure will be called again with an iterator configured to continue where the first one finished.
+    ///
+    /// In this example, an asynchronous sequence of Strings encodes sentences by prefixing each word sequence with a number.
+    /// The number indicates how many words will be read and concatenated into a complete sentence.
+    ///
+    /// The closure provided to the `iteratorMap(_:)` first reads the first available string, interpreting it as a number.
+    /// Then, it will loop the specified number of times, accumulating those words into an array, that is finally assembled into a sentence.
+    ///
+    ///     let dataStream = ["2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "1", "Bye!"]
+    ///
+    ///     let sentenceStream = dataStream.iteratorMap { iterator -> String? in
+    ///         var count = Int(try await iterator.next() ?? "")!
+    ///
+    ///         var results: [String] = []
+    ///
+    ///         while count > 0, let next = try await iterator.next() {
+    ///             results.append(next)
+    ///             count -= 1
+    ///         }
+    ///
+    ///         return results.joined(separator: " ")
+    ///     }
+    ///
+    ///     for await sentence in sentenceStream {
+    ///         print("\"\(sentence)\"", terminator: ", ")
+    ///     }
+    ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
+    ///
+    /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early.
+    /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
+    @inlinable
+    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AnyReadableSequence<Element>.AsyncIterator>) async -> Transformed) -> AsyncIteratorMapSequence<AnyReadableSequence<Element>, Transformed> {
+        AsyncIteratorMapSequence(AnyReadableSequence(self), transform: transform)
+    }
+    
+    /// Creates an asynchronous sequence that maps the given closure over an iterator for the sequence, which can itself accept multiple reads.
+    ///
+    /// When finished reading from the iterator, return your completed object, and the closure will be called again with an iterator configured to continue where the first one finished.
+    ///
+    /// In this example, an asynchronous sequence of Strings encodes sentences by prefixing each word sequence with a number.
+    /// The number indicates how many words will be read and concatenated into a complete sentence.
+    ///
+    /// The closure provided to the `iteratorMap(_:)` first reads the first available string, interpreting it as a number.
+    /// Then, it will loop the specified number of times, accumulating those words into an array, that is finally assembled into a sentence.
+    ///
+    ///     let dataStream = ... // "2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "1", "Bye!"
+    ///
+    ///     let sentenceStream = dataStream.iteratorMap { iterator -> String? in
+    ///         guard var count = Int(try await iterator.next() ?? "") else {
+    ///             throw SentenceParsing.invalidWordCount
+    ///         }
+    ///
+    ///         var results: [String] = []
+    ///
+    ///         while count > 0, let next = try await iterator.next() {
+    ///             results.append(next)
+    ///             count -= 1
+    ///         }
+    ///
+    ///         guard count == 0 else {
+    ///             throw SentenceParsing.missingFinalWords
+    ///         }
+    ///
+    ///         return results.joined(separator: " ")
+    ///     }
+    ///
+    ///     for try await sentence in sentenceStream {
+    ///         print("\"\(sentence)\"", terminator: ", ")
+    ///     }
+    ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
+    ///
+    /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early, as will throwing an error.
+    /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
+    @inlinable
+    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AnyReadableSequence<Element>.AsyncIterator>) async throws -> Transformed) -> AsyncThrowingIteratorMapSequence<AnyReadableSequence<Element>, Transformed> {
+        AsyncThrowingIteratorMapSequence(AnyReadableSequence(self), transform: transform)
+    }
+}
+
 /// An asynchronous sequence that maps the given closure over the asynchronous sequence’s elements by providing it with the base sequence's iterator to assemble multiple reads into a single transformed object.
 public struct AsyncIteratorMapSequence<Base: AsyncSequence, Transformed> {
     @usableFromInline

--- a/Sources/AsyncSequenceReader/AsyncReadSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadSequence.swift
@@ -36,6 +36,7 @@ extension AsyncIteratorProtocol {
             results = try await sequenceTransform(readSequence)
             wrappedIterator = readSequence.baseIterator
         }
+        precondition(wrappedIterator.unconsumedBuffer.isEmpty, "A transform was requested, but the sequence was left in a state where the next value will never be read (fix: Use AnyReadableSequence(iterator) instead of calling `.transform` on `iterator` directly)")
         self = wrappedIterator.baseIterator
         
         return results

--- a/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToCountSequence.swift
@@ -15,7 +15,7 @@ extension AsyncIteratorProtocol {
     /// - Returns: A collection with exactly `count` elements, or `nil` if the sequence is finished.
     /// - Throws: `AsyncSequenceReaderError.insufficientElements` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect(_ count: Int) async throws -> [Element]? {
-        assert(count >= 0, "count must be larger than 0")
+        assert(count >= 0, "count must be larger than or equal to 0")
         return try await collect(min: count, max: count)
     }
     
@@ -28,7 +28,9 @@ extension AsyncIteratorProtocol {
     /// - Throws: `AsyncSequenceReaderError.insufficientElements` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect(min minCount: Int = 0, max maxCount: Int) async throws -> [Element]? {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
-        precondition(minCount >= 0, "minCount must be larger than 0")
+        precondition(minCount >= 0, "minCount must be larger than or equal to 0")
+        if maxCount == 0 { return [] }
+        
         var result = [Element]()
         result.reserveCapacity(minCount)
         
@@ -82,7 +84,7 @@ extension AsyncIteratorProtocol {
         _ count: Int,
         sequenceTransform: sending (sending AsyncReadUpToCountSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? {
-        assert(count >= 0, "count must be larger than 0")
+        assert(count >= 0, "count must be larger than or equal to 0")
         return try await collect(min: count, max: count, sequenceTransform: sequenceTransform)
     }
     
@@ -111,17 +113,22 @@ extension AsyncIteratorProtocol {
     ///     }
     ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye?"
     ///
+    /// - Important: This variation reads ahead a single byte
+    ///
     /// - Parameter minCount: The minimum number of elements the `sequenceTransform` closure will attempt have access to. If this number cannot be guaranteed, an error will be thrown.
     /// - Parameter maxCount: The maximum number of elements the `sequenceTransform` closure will have access to.
     /// - Parameter sequenceTransform: A transformation that accepts a sequence of the specified size that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     /// - Throws: `AsyncSequenceReaderError.insufficientElements` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect<Transformed>(
-        min minCount: Int = 0,
+        min minCount: Int = 1,
         max maxCount: Int,
         sequenceTransform: sending (sending AsyncReadUpToCountSequence<Self>) async throws -> Transformed
     ) async throws -> Transformed? {
-        try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
+        /// It is unsafe to read ahead in this case, so exit early if we know we won't need to read.
+        if maxCount == 0 { return nil }
+        assert(minCount >= 1, "minCount must be larger than or equal to 1, or the first value risks getting dropped")
+        return try await transform(with: sequenceTransform) { .init($0, minCount: minCount, maxCount: maxCount) }
     }
 }
 
@@ -222,7 +229,7 @@ public final class AsyncReadUpToCountSequence<BaseIterator: AsyncIteratorProtoco
         maxCount: Int
     ) {
         precondition(minCount <= maxCount, "maxCount must be larger than or equal to minCount")
-        precondition(minCount >= 0, "minCount must be larger than 0")
+        precondition(minCount >= 0, "minCount must be larger than or equal to 0")
         self.baseIterator = baseIterator
         self.minCount = minCount
         self.maxCount = maxCount

--- a/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncReadUpToElementsSequence.swift
@@ -8,10 +8,9 @@
 //
 
 extension AsyncIteratorProtocol {
-    
     /// Collect elements into a sequence until the termination sequence is encountered, and return them as an array, including the termination sequence.
     ///
-    /// If the termination sequence was not detected before the end of the stream, or the specified maximum, an error will be thrown.
+    /// If the termination sequence was not detected before the end of the stream, or more than the specified maximum elements are read, an error will be thrown.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -42,7 +41,7 @@ extension AsyncIteratorProtocol {
     
     /// Collect elements into a sequence until the termination sequence is encountered, and return them as an array, including the termination sequence.
     ///
-    /// If the termination sequence was not detected before the end of the stream, or the specified maximum, an error will be thrown.
+    /// If the termination sequence was not detected before the end of the stream, or more than the specified maximum elements are read, an error will be thrown.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -65,20 +64,20 @@ extension AsyncIteratorProtocol {
     /// - Returns: An array of the collected elements, or `nil` if the sequence was already finished.
     /// - Throws: `AsyncSequenceReaderError.terminationNotFound` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect(
-        upToIncluding termination: [Element],
+        upToIncluding termination: some Collection<Element>,
         throwsIfOver maximumBufferSize: Int
     ) async throws -> [Element]? where Element: Equatable {
-        precondition(!termination.isEmpty, "stopSequence must not be empty")
+        precondition(!termination.isEmpty, "termination must not be empty")
         var result = [Element]()
         
         while let next = try await _nextIsolated() {
             if result.count == maximumBufferSize {
-                throw AsyncSequenceReaderError.terminationNotFound(maximum: maximumBufferSize, actual: result.count)
+                throw AsyncSequenceReaderError.terminationNotFound(maximum: maximumBufferSize, actual: result.count + 1)
             }
             
             result.append(next)
             
-            if result.suffix(termination.count) == termination {
+            if result.suffix(termination.count).elementsEqual(termination) {
                 return result
             }
         }
@@ -90,7 +89,7 @@ extension AsyncIteratorProtocol {
     
     /// Collect elements into a sequence until the termination sequence is encountered, and return them as an array, excluding the termination sequence.
     ///
-    /// If the termination sequence was not detected before the end of the stream, or the specified maximum, an error will be thrown.
+    /// If the termination sequence was not detected before the end of the stream, or more than the specified maximum elements are read, an error will be thrown.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -121,7 +120,7 @@ extension AsyncIteratorProtocol {
     
     /// Collect elements into a sequence until the termination sequence is encountered, and return them as an array, excluding the termination sequence.
     ///
-    /// If the termination sequence was not detected before the end of the stream, or the specified maximum, an error will be thrown.
+    /// If the termination sequence was not detected before the end of the stream, or more than the specified maximum elements are read, an error will be thrown.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -144,15 +143,18 @@ extension AsyncIteratorProtocol {
     /// - Returns: An array of the collected elements, or `nil` if the sequence was already finished.
     /// - Throws: `AsyncSequenceReaderError.terminationNotFound` if a complete byte sequence could not be returned by the time the sequence ended.
     public mutating func collect(
-        upToExcluding termination: [Element],
+        upToExcluding termination: some Collection<Element>,
         throwsIfOver maximumBufferSize: Int
     ) async throws -> [Element]? where Element: Equatable {
         try await collect(upToIncluding: termination, throwsIfOver: maximumBufferSize)?.dropLast(termination.count)
     }
+}
+
+extension AsyncIteratorProtocol {
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
     ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
+    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count).elementsEqual(termination)`.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -182,14 +184,14 @@ extension AsyncIteratorProtocol {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self, Array<Element>>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
     ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
+    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count).elementsEqual(termination)`.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -217,83 +219,12 @@ extension AsyncIteratorProtocol {
     /// - Parameter termination: The sequence of elements marking the end of the sequence the `sequenceTransform` closure will have access to.
     /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: [Element],
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
-    ) async throws -> Transformed? where Element: Equatable {
-        try await transform(with: sequenceTransform) { .init($0, termination: termination) }
-    }
-    
-    /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
-    ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
-    ///
-    /// In this example, an asynchronous sequence of Characters represents a list of words.
-    ///
-    /// The closure provided to the `iteratorMap(_:)` reads characters up to and inluding the termination provided, splitting the sequence into an array of words.
-    ///
-    ///     let dataStream = ... // "apple orange banana kiwi kumquat pear pineapple"
-    ///
-    ///     let wordStream = dataStream.iteratorMap { iterator -> String? in
-    ///         let word = await iterator.collect(upToIncluding: " ") { sequence -> String in
-    ///             await sequence.reduce(into: "") { $0.append($1) }
-    ///         }
-    ///
-    ///         if let word = word, word.hasSuffix(" ") {
-    ///             return String(word.dropLast(1))
-    ///         }
-    ///
-    ///         return word
-    ///     }
-    ///
-    ///     for await word in wordStream {
-    ///         print("\"\(word)\"", terminator: ", ")
-    ///     }
-    ///     // Prints: "apple", "orange", "banana", "kiwi", "kumquat", "pear", "pineapple",
-    ///
-    /// - Parameter termination: The element marking the end of the sequence the `sequenceTransform` closure will have access to.
-    /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
-    /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: Element,
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
-    ) async throws -> Transformed? where Element: Equatable {
-        try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
-    }
-    
-    /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
-    ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
-    ///
-    /// In this example, an asynchronous sequence of Characters represents a list of words.
-    ///
-    /// The closure provided to the `iteratorMap(_:)` reads characters up to and inluding the termination provided, splitting the sequence into an array of words.
-    ///
-    ///     let dataStream = ... // "apple orange banana kiwi kumquat pear pineapple"
-    ///
-    ///     let wordStream = dataStream.iteratorMap { iterator -> String? in
-    ///         let word = await iterator.collect(upToIncluding: [" "]) { sequence -> String in
-    ///             await sequence.reduce(into: "") { $0.append($1) }
-    ///         }
-    ///
-    ///         if let word = word, word.hasSuffix(" ") {
-    ///             return String(word.dropLast(1))
-    ///         }
-    ///
-    ///         return word
-    ///     }
-    ///
-    ///     for await word in wordStream {
-    ///         print("\"\(word)\"", terminator: ", ")
-    ///     }
-    ///     // Prints: "apple", "orange", "banana", "kiwi", "kumquat", "pear", "pineapple",
-    ///
-    /// - Parameter termination: The sequence of elements marking the end of the sequence the `sequenceTransform` closure will have access to.
-    /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
-    /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: [Element],
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
+    public mutating func collect<
+        TerminationCollection: Collection<Element>,
+        Transformed
+    >(
+        upToIncluding termination: TerminationCollection,
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self, TerminationCollection>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
@@ -303,7 +234,7 @@ extension AsyncBufferedIterator {
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
     ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
+    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count).elementsEqual(termination)`.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -333,14 +264,14 @@ extension AsyncBufferedIterator {
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
     public mutating func collect<Transformed>(
         upToIncluding termination: Element,
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async -> Transformed
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self, Array<Element>>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
     }
     
     /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
     ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
+    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count).elementsEqual(termination)`.
     ///
     /// In this example, an asynchronous sequence of Characters represents a list of words.
     ///
@@ -368,102 +299,34 @@ extension AsyncBufferedIterator {
     /// - Parameter termination: The sequence of elements marking the end of the sequence the `sequenceTransform` closure will have access to.
     /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
     /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: [Element],
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<BaseIterator>) async -> Transformed
-    ) async throws -> Transformed? where Element: Equatable {
-        try await transform(with: sequenceTransform) { .init($0, termination: termination) }
-    }
-    
-    /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
-    ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
-    ///
-    /// In this example, an asynchronous sequence of Characters represents a list of words.
-    ///
-    /// The closure provided to the `iteratorMap(_:)` reads characters up to and inluding the termination provided, splitting the sequence into an array of words.
-    ///
-    ///     let dataStream = ... // "apple orange banana kiwi kumquat pear pineapple"
-    ///
-    ///     let wordStream = dataStream.iteratorMap { iterator -> String? in
-    ///         let word = await iterator.collect(upToIncluding: " ") { sequence -> String in
-    ///             await sequence.reduce(into: "") { $0.append($1) }
-    ///         }
-    ///
-    ///         if let word = word, word.hasSuffix(" ") {
-    ///             return String(word.dropLast(1))
-    ///         }
-    ///
-    ///         return word
-    ///     }
-    ///
-    ///     for await word in wordStream {
-    ///         print("\"\(word)\"", terminator: ", ")
-    ///     }
-    ///     // Prints: "apple", "orange", "banana", "kiwi", "kumquat", "pear", "pineapple",
-    ///
-    /// - Parameter termination: The element marking the end of the sequence the `sequenceTransform` closure will have access to.
-    /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
-    /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: Element,
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<Self>) async throws -> Transformed
-    ) async throws -> Transformed? where Element: Equatable {
-        try await collect(upToIncluding: [termination], sequenceTransform: sequenceTransform)
-    }
-    
-    /// Collect elements into a sequence until the termination sequence is encountered, and transform it using the provided closure.
-    ///
-    /// - Note: It is up to the caller to verify if the termination sequence was encountered or not, which can easily be done by checking `result.suffix(termination.count) == termination`.
-    ///
-    /// In this example, an asynchronous sequence of Characters represents a list of words.
-    ///
-    /// The closure provided to the `iteratorMap(_:)` reads characters up to and inluding the termination provided, splitting the sequence into an array of words.
-    ///
-    ///     let dataStream = ... // "apple orange banana kiwi kumquat pear pineapple"
-    ///
-    ///     let wordStream = dataStream.iteratorMap { iterator -> String? in
-    ///         let word = await iterator.collect(upToIncluding: [" "]) { sequence -> String in
-    ///             await sequence.reduce(into: "") { $0.append($1) }
-    ///         }
-    ///
-    ///         if let word = word, word.hasSuffix(" ") {
-    ///             return String(word.dropLast(1))
-    ///         }
-    ///
-    ///         return word
-    ///     }
-    ///
-    ///     for await word in wordStream {
-    ///         print("\"\(word)\"", terminator: ", ")
-    ///     }
-    ///     // Prints: "apple", "orange", "banana", "kiwi", "kumquat", "pear", "pineapple",
-    ///
-    /// - Parameter termination: The sequence of elements marking the end of the sequence the `sequenceTransform` closure will have access to.
-    /// - Parameter sequenceTransform: A transformation that accepts a sequence containing elements up to the termination that can be read from, or stopped prematurely by returning early. The receiving iterator will have moved forward by the same amount of items consumed within `sequenceTransform`.
-    /// - Returns: A transformed value as returned by `sequenceTransform`, or `nil` if the sequence was already finished.
-    public mutating func collect<Transformed>(
-        upToIncluding termination: [Element],
-        sequenceTransform: sending (AsyncReadUpToElementsSequence<BaseIterator>) async throws -> Transformed
+    public mutating func collect<
+        TerminationCollection: Collection<Element>,
+        Transformed
+    >(
+        upToIncluding termination: TerminationCollection,
+        sequenceTransform: sending (AsyncReadUpToElementsSequence<BaseIterator, TerminationCollection>) async throws -> Transformed
     ) async throws -> Transformed? where Element: Equatable {
         try await transform(with: sequenceTransform) { .init($0, termination: termination) }
     }
 }
 
 /// An asynchronous sequence that will read from a mutable iterator so long as the specified conditions are valid.
-public class AsyncReadUpToElementsSequence<BaseIterator: AsyncIteratorProtocol>: AsyncReadSequence where BaseIterator.Element: Equatable {
+public class AsyncReadUpToElementsSequence<
+    BaseIterator: AsyncIteratorProtocol,
+    TerminationCollection: Collection
+>: AsyncReadSequence where TerminationCollection.Element == BaseIterator.Element, TerminationCollection.Element: Equatable {
     /// The baseIterator to read from.
     ///
     /// When finished with the sequence, callers should read back this value so they can continue iterating on the sequence.
     public var baseIterator: AsyncBufferedIterator<BaseIterator>
     
     @usableFromInline
-    let termination: [Element]
+    let termination: TerminationCollection
     
     @usableFromInline
     init(
         _ baseIterator: AsyncBufferedIterator<BaseIterator>,
-        termination: [Element]
+        termination: TerminationCollection
     ) {
         precondition(!termination.isEmpty, "termination must not be empty")
         self.baseIterator = baseIterator
@@ -497,7 +360,7 @@ extension AsyncReadUpToElementsSequence: AsyncSequence {
         @inlinable
         public mutating func next() async rethrows -> Element? {
             guard
-                bufferedSuffix != readSequence.termination,
+                !bufferedSuffix.elementsEqual(readSequence.termination),
                 let next = try await readSequence.baseIterator.next()
             else { return nil }
             

--- a/Tests/AsyncSequenceReaderTests/AnyReadableSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AnyReadableSequenceTests.swift
@@ -1,0 +1,51 @@
+//
+//  AnyReadableSequenceTests.swift
+//  https://github.com/mochidev/AsyncSequenceReader
+//
+//  Created by Dimitri Bouniol on 2026-04-29.
+//  Copyright © 2021-26 Mochi Development, Inc. All rights reserved.
+//  async-sequence-reader-watermark: 7E20A9CAB0604E89B17C6747A34F00C0
+//
+
+@testable import AsyncSequenceReader
+import Testing
+
+@Suite struct AnyReadableSequenceTests {
+    @Test func castSequence() async throws {
+        let sequence = AnyReadableSequence([0, 1, 2])
+        
+        var iterator = sequence.makeAsyncIterator()
+        
+        #expect(try await iterator.next() == 0)
+        #expect(try await iterator.next() == 1)
+        #expect(try await iterator.next() == 2)
+        #expect(try await iterator.next() == nil)
+    }
+    
+    @Test func castAsyncSequence() async throws {
+        let sequence = AnyReadableSequence(AsyncStream { continuation in
+            continuation.yield(0)
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.finish()
+        })
+        
+        var iterator = sequence.makeAsyncIterator()
+        
+        #expect(try await iterator.next() == 0)
+        #expect(try await iterator.next() == 1)
+        #expect(try await iterator.next() == 2)
+        #expect(try await iterator.next() == nil)
+    }
+    
+    @Test func castThrowingAsyncSequence() async throws {
+        let sequence = AnyReadableSequence(ThrowingTestSequence(base: [0, 1, 2]))
+        
+        var iterator = sequence.makeAsyncIterator()
+        
+        #expect(try await iterator.next() == 0)
+        #expect(try await iterator.next() == 1)
+        #expect(try await iterator.next() == 2)
+        #expect(try await iterator.next() == nil)
+    }
+}

--- a/Tests/AsyncSequenceReaderTests/AsyncBufferedIteratorTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncBufferedIteratorTests.swift
@@ -10,6 +10,14 @@
 @testable import AsyncSequenceReader
 import Testing
 
+extension AsyncIteratorProtocol {
+    mutating func nonIsolatedNext() async rethrows -> Element? {
+        nonisolated(unsafe) var iterator = self
+        defer { self = iterator }
+        return try await iterator.next()
+    }
+}
+
 @Suite struct AsyncBufferedIteratorTests {
     @Test func bufferIteratorFromStream() async throws {
         let testStream = AsyncStream<Int> { continuation in
@@ -36,7 +44,7 @@ import Testing
         #expect(await bufferedIterator.hasMoreData() == true)
         #expect(await bufferedIterator.hasMoreData() == true)
         #expect(await bufferedIterator.next() == 5)
-        #expect(await bufferedIterator.next() == 6)
+        #expect(try await bufferedIterator.nonIsolatedNext() == 6)
         #expect(await bufferedIterator.next() == 7)
         #expect(await bufferedIterator.next() == 8)
         #expect(await bufferedIterator.hasMoreData() == true)
@@ -70,7 +78,7 @@ import Testing
         #expect(await bufferedIterator.hasMoreData() == true)
         #expect(await bufferedIterator.hasMoreData() == true)
         #expect(await bufferedIterator.next() == 5)
-        #expect(await bufferedIterator.next() == 6)
+        #expect(try await bufferedIterator.nonIsolatedNext() == 6)
         #expect(await bufferedIterator.next() == 7)
         #expect(await bufferedIterator.next() == 8)
         #expect(await bufferedIterator.hasMoreData() == true)
@@ -104,7 +112,7 @@ import Testing
         #expect(try await bufferedIterator.hasMoreData() == true)
         #expect(try await bufferedIterator.hasMoreData() == true)
         #expect(try await bufferedIterator.next() == 5)
-        #expect(try await bufferedIterator.next() == 6)
+        #expect(try await bufferedIterator.nonIsolatedNext() == 6)
         #expect(try await bufferedIterator.next() == 7)
         #expect(try await bufferedIterator.next() == 8)
         #expect(try await bufferedIterator.hasMoreData() == true)

--- a/Tests/AsyncSequenceReaderTests/AsyncIteratorMapSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncIteratorMapSequenceTests.swift
@@ -39,6 +39,7 @@ import Testing
         #expect(await resultsIterator.next() == "My name is Dimitri.")
         #expect(await resultsIterator.next() == "")
         #expect(await resultsIterator.next() == "Bye!")
+        #expect(await resultsIterator.next() == nil)
     }
     
     @Test func iteratorMapFromInvalidStream() async throws {
@@ -101,6 +102,7 @@ import Testing
         #expect(await resultsIterator.next() == "My name is Dimitri.")
         #expect(await resultsIterator.next() == "")
         #expect(await resultsIterator.next() == "Bye!")
+        #expect(await resultsIterator.next() == nil)
     }
     
     @Test func iteratorMapFromInvalidTestSequence() async throws {
@@ -157,6 +159,7 @@ import Testing
         #expect(try await resultsIterator.next() == "My name is Dimitri.")
         #expect(try await resultsIterator.next() == "")
         #expect(try await resultsIterator.next() == "Bye!")
+        #expect(try await resultsIterator.next() == nil)
     }
     
     @Test func iteratorMapFromInvalidThrowingTestSequence() async throws {
@@ -165,6 +168,63 @@ import Testing
         let testStream = ThrowingTestSequence(base: ["2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "2", "Bye!"])
         
         let results = testStream.iteratorMap { iterator -> String? in
+            var count = Int(try await iterator.next() ?? "")!
+            
+            var results: [String] = []
+            
+            while count > 0, let next = try await iterator.next() {
+                results.append(next)
+                count -= 1
+            }
+            
+            guard count == 0 else {
+                throw LocalError()
+            }
+            
+            return results.joined(separator: " ")
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "Hello, World!")
+        #expect(try await resultsIterator.next() == "My name is Dimitri.")
+        #expect(try await resultsIterator.next() == "")
+        await #expect(throws: LocalError.self) {
+            try await resultsIterator.next()
+        }
+    }
+    
+    @Test func iteratorMapFromSequence() async throws {
+        let sequence = ["2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "1", "Bye!"]
+        
+        let results = sequence.iteratorMap { iterator -> String? in
+            var count = Int(try! await iterator.next() ?? "")!
+            
+            var results: [String] = []
+            
+            while count > 0, let next = try! await iterator.next() {
+                results.append(next)
+                count -= 1
+            }
+            
+            return results.joined(separator: " ")
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "Hello, World!")
+        #expect(try await resultsIterator.next() == "My name is Dimitri.")
+        #expect(try await resultsIterator.next() == "")
+        #expect(try await resultsIterator.next() == "Bye!")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapFromInvalidSequence() async throws {
+        struct LocalError: Error {}
+        
+        let sequence = ["2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "2", "Bye!"]
+        
+        let results = sequence.iteratorMap { iterator -> String? in
             var count = Int(try await iterator.next() ?? "")!
             
             var results: [String] = []

--- a/Tests/AsyncSequenceReaderTests/AsyncReadUpToCountSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncReadUpToCountSequenceTests.swift
@@ -209,4 +209,443 @@ import Testing
             try await resultsIterator.next()
         }
     }
+    
+    @Test func assertsIteratorMapOnCollectNegativeCount() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            
+            _ = try await sequence.iteratorMap { iterator -> String? in
+                try await iterator.collect(-1) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }.reduce(into: [], { $0.append($1) })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:169: Assertion failed: count must be larger than 0")
+        #endif
+    }
+    
+    @Test func assertsIteratorMapOnCollectNegativeMin() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            
+            _ = try await sequence.iteratorMap { iterator -> String? in
+                try await iterator.collect(min: -1, max: 0) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }.reduce(into: [], { $0.append($1) })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:232: Precondition failed: minCount must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsIteratorMapOnCollectNegativeMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            
+            _ = try await sequence.iteratorMap { iterator -> String? in
+                try await iterator.collect(min: -1, max: -1) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }.reduce(into: [], { $0.append($1) })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:232: Precondition failed: minCount must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsIteratorMapOnCollectInvertedMinMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            
+            _ = try await sequence.iteratorMap { iterator -> String? in
+                try await iterator.collect(min: 0, max: -1) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }.reduce(into: [], { $0.append($1) })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:231: Precondition failed: maxCount must be larger than or equal to minCount")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnTransformingCollectNegativeCount() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(-1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:87: Assertion failed: count must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnCollectNegativeCount() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(-1)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:18: Assertion failed: count must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnTransformingCollectZeroMin() async throws {
+        #if DEBUG
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: 0, max: 1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:130: Assertion failed: minCount must be larger than or equal to 1, or the first value risks getting dropped")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnTransformingCollectNegativeMin() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: -1, max: 1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:130: Assertion failed: minCount must be larger than or equal to 1, or the first value risks getting dropped")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnCollectNegativeMin() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: -1, max: 1)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:31: Precondition failed: minCount must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnTransformingCollectNegativeMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: -1, max: -1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:130: Assertion failed: minCount must be larger than or equal to 1, or the first value risks getting dropped")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnCollectNegativeMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: -1, max: -1)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:31: Precondition failed: minCount must be larger than or equal to 0")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnTransformingCollectInvertedMinMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: 0, max: -1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:130: Assertion failed: minCount must be larger than or equal to 1, or the first value risks getting dropped")
+        #endif
+    }
+    
+    @Test func assertsRawIteratorOnCollectInvertedMinMax() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let sequence = 0...10
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            
+            _ = try await iterator.collect(min: 0, max: -1)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToCountSequence.swift:30: Precondition failed: maxCount must be larger than or equal to minCount")
+        #endif
+    }
+    
+    @Test func iteratorMapCanCollectZero() async throws {
+        let sequence = 0...10
+        
+        let results = sequence.iteratorMap { iterator -> String? in
+            let result1 = try await iterator.collect(0) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result1 == "")
+            
+            let result2 = try await iterator.collect(min: 0, max: 0) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result2 == "")
+            
+            let result3 = try await iterator.collect(0)
+            #expect(result3 == [])
+            
+            let result4 = try await iterator.collect(min: 0, max: 0)
+            #expect(result4 == [])
+            
+            return try await iterator.collect(max: 11).map(String.init)
+        }
+        
+        let allValues = try await results.reduce(into: [], { $0.append($1) })
+        #expect(allValues == ["[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"])
+    }
+    
+    @Test func iteratorMapCanCollectOne() async throws {
+        let sequence = 0...10
+        
+        let results = sequence.iteratorMap { iterator -> String? in
+            let result1 = try await iterator.collect(1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result1 == "0")
+            
+            let result2 = try await iterator.collect(min: 0, max: 1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result2 == "1")
+            
+            let result3 = try await iterator.collect(min: 1, max: 1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result3 == "2")
+            
+            let result4 = try await iterator.collect(1)
+            #expect(result4 == [3])
+            
+            let result5 = try await iterator.collect(min: 0, max: 1)
+            #expect(result5 == [4])
+            
+            let result6 = try await iterator.collect(min: 1, max: 1)
+            #expect(result6 == [5])
+            
+            return try await iterator.collect(max: 5).map(String.init)
+        }
+        
+        let allValues = try await results.reduce(into: [], { $0.append($1) })
+        #expect(allValues == ["[6, 7, 8, 9, 10]"])
+    }
+    
+    @Test func iteratorMapCanCollectAll() async throws {
+        let sequence = 0...10
+        
+        let allValues1 = try await sequence.iteratorMap { iterator -> String? in
+            try await iterator.collect(11) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }.reduce(into: [], { $0.append($1) })
+        #expect(allValues1 == ["0 1 2 3 4 5 6 7 8 9 10"])
+        
+        let allValues2 = try await sequence.iteratorMap { iterator -> String? in
+            try await iterator.collect(max: 12) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+        }.reduce(into: [], { $0.append($1) })
+        #expect(allValues2 == ["0 1 2 3 4 5 6 7 8 9 10"])
+        
+        let allValues3 = try await sequence.iteratorMap { iterator in
+            try await iterator.collect(max: 12)
+        }.reduce(into: [], { $0.append($1) })
+        #expect(allValues3 == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+    }
+    
+    @Test func rawIteratorCanCollectZero() async throws {
+        let sequence = 0...10
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(0) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }?.reduce(into: [], { $0.append($1) })
+            #expect(result == nil)
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 0, max: 0) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }?.reduce(into: [], { $0.append($1) })
+            #expect(result == nil)
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(0)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 0, max: 0)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [])
+        }
+    }
+    
+    @Test func rawIteratorCanCollectOne() async throws {
+        let sequence = 0...10
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }?.reduce(into: [], { $0.append($1) })
+            #expect(result == ["0"])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 1, max: 1) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }?.reduce(into: [], { $0.append($1) })
+            #expect(result == ["0"])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(1)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 0, max: 1)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 1, max: 1)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0])
+        }
+    }
+    
+    @Test func rawIteratorCanCollectAll() async throws {
+        let sequence = 0...10
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(11) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result == "0 1 2 3 4 5 6 7 8 9 10")
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 1, max: 15) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result == "0 1 2 3 4 5 6 7 8 9 10")
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(11)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 0, max: 15)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 11, max: 15)?.reduce(into: [], { $0.append($1) })
+            #expect(result == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        }
+    }
+    
+    @Test func rawIteratorCollectsFromInvalidCount() async throws {
+        let sequence = 0...10
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            await #expect(throws: AsyncSequenceReaderError.insufficientElements(minimum: 12, actual: 11)) {
+                let _ = try await iterator.collect(12) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            await #expect(throws: AsyncSequenceReaderError.insufficientElements(minimum: 12, actual: 11)) {
+                let _ = try await iterator.collect(min: 12, max: 15) { sequence -> String in
+                    try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+                }
+            }
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            await #expect(throws: AsyncSequenceReaderError.insufficientElements(minimum: 12, actual: 11)) {
+                let _ = try await iterator.collect(12)?.reduce(into: [], { $0.append($1) })
+            }
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            await #expect(throws: AsyncSequenceReaderError.insufficientElements(minimum: 12, actual: 11)) {
+                let _ = try await iterator.collect(min: 12, max: 15)?.reduce(into: [], { $0.append($1) })
+            }
+        }
+    }
+    
+    @Test func rawIteratorCollectsFromEmptySequence() async throws {
+        let sequence: [Int] = []
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(12) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result == nil)
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 12, max: 15) { sequence -> String in
+                try await sequence.reduce(into: "") { $0 += ($0.isEmpty ? "" : " ") + String($1) }
+            }
+            #expect(result == nil)
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(12)?.reduce(into: [], { $0.append($1) })
+            #expect(result == nil)
+        }
+        
+        do {
+            var iterator = AnyReadableSequence(sequence).makeAsyncIterator()
+            let result = try await iterator.collect(min: 12, max: 15)?.reduce(into: [], { $0.append($1) })
+            #expect(result == nil)
+        }
+    }
 }

--- a/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncReadUpToElementsSequenceTests.swift
@@ -11,60 +11,167 @@
 import Testing
 
 @Suite struct AsyncReadUpToElementsSequenceTests {
-    @Test func iteratorMapUpToIncludingSequence() async throws {
-        struct LocalError: Error {}
-        
-        let testStream = TestSequence(base: "apple orange banana kiwi kumquat pear pineapple")
-        
-        let results = testStream.iteratorMap { iterator -> String? in
-            let word = try await iterator.collect(upToIncluding: " ") { sequence -> String in
-                try await sequence.reduce(into: "") { $0.append($1) }
-            }
-            
-            if let word = word, word.hasSuffix(" ") {
-                return String(word.dropLast(1))
-            }
-            return word
-        }
-        
-        var resultsIterator = results.makeAsyncIterator()
-        
-        #expect(try await resultsIterator.next() == "apple")
-        #expect(try await resultsIterator.next() == "orange")
-        #expect(try await resultsIterator.next() == "banana")
-        #expect(try await resultsIterator.next() == "kiwi")
-        #expect(try await resultsIterator.next() == "kumquat")
-        #expect(try await resultsIterator.next() == "pear")
-        #expect(try await resultsIterator.next() == "pineapple")
+    @Test func upToIncludingReturnsNilIfEmpty() async throws {
+        var iterator = AnyReadableSequence("").makeAsyncIterator()
+        #expect(try await iterator.collect(upToIncluding: " " as Character, throwsIfOver: 10) == nil)
     }
     
     @Test func iteratorMapUpToIncluding() async throws {
-        struct LocalError: Error {}
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple "
         
-        let testStream = TestSequence(base: "apple orange banana kiwi kumquat pear pineapple ")
-        
-        let results = testStream.iteratorMap { iterator -> String? in
-            (try await iterator.collect(upToIncluding: " ", throwsIfOver: 100)).map { String($0.dropLast()) }
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: " " as Character, throwsIfOver: 10)).map { String($0) }
         }
         
         var resultsIterator = results.makeAsyncIterator()
         
-        #expect(try await resultsIterator.next() == "apple")
-        #expect(try await resultsIterator.next() == "orange")
-        #expect(try await resultsIterator.next() == "banana")
-        #expect(try await resultsIterator.next() == "kiwi")
-        #expect(try await resultsIterator.next() == "kumquat")
-        #expect(try await resultsIterator.next() == "pear")
-        #expect(try await resultsIterator.next() == "pineapple")
+        #expect(try await resultsIterator.next() == "apple ")
+        #expect(try await resultsIterator.next() == "orange ")
+        #expect(try await resultsIterator.next() == "banana ")
+        #expect(try await resultsIterator.next() == "kiwi ")
+        #expect(try await resultsIterator.next() == "kumquat ")
+        #expect(try await resultsIterator.next() == "pear ")
+        #expect(try await resultsIterator.next() == "pineapple ")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingThrowsIfNotFound() async throws {
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: " " as Character, throwsIfOver: 10)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple ")
+        #expect(try await resultsIterator.next() == "orange ")
+        #expect(try await resultsIterator.next() == "banana ")
+        #expect(try await resultsIterator.next() == "kiwi ")
+        #expect(try await resultsIterator.next() == "kumquat ")
+        #expect(try await resultsIterator.next() == "pear ")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 10, actual: 9)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingThrowsIfTooLong() async throws {
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple apple pen"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: " " as Character, throwsIfOver: 9)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple ")
+        #expect(try await resultsIterator.next() == "orange ")
+        #expect(try await resultsIterator.next() == "banana ")
+        #expect(try await resultsIterator.next() == "kiwi ")
+        #expect(try await resultsIterator.next() == "kumquat ")
+        #expect(try await resultsIterator.next() == "pear ")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 9, actual: 10)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func upToIncludingSequenceReturnsNilIfEmpty() async throws {
+        var iterator = AnyReadableSequence("").makeAsyncIterator()
+        #expect(try await iterator.collect(upToIncluding: ", ", throwsIfOver: 10) == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingSequence() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple, "
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: ", ", throwsIfOver: 17)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange, ")
+        #expect(try await resultsIterator.next() == "banana kiwi, ")
+        #expect(try await resultsIterator.next() == "kumquat pear, ")
+        #expect(try await resultsIterator.next() == "pineapple apple, ")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingSequenceIfNotFound() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: ", ", throwsIfOver: 17)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange, ")
+        #expect(try await resultsIterator.next() == "banana kiwi, ")
+        #expect(try await resultsIterator.next() == "kumquat pear, ")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 17, actual: 15)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingSequenceIfNotFoundAtBoundary() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: ", ", throwsIfOver: 15)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange, ")
+        #expect(try await resultsIterator.next() == "banana kiwi, ")
+        #expect(try await resultsIterator.next() == "kumquat pear, ")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 15, actual: 15)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToIncludingSequenceIfTooLong() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple, "
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToIncluding: ", ", throwsIfOver: 16)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange, ")
+        #expect(try await resultsIterator.next() == "banana kiwi, ")
+        #expect(try await resultsIterator.next() == "kumquat pear, ")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 16, actual: 17)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func trapsIfUpToIncludingTerminationIsEmpty() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            var inputSequence = AnyReadableSequence("").makeAsyncIterator()
+            let _ = try await inputSequence.collect(upToIncluding: "", throwsIfOver: 10)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToElementsSequence.swift:70: Precondition failed: termination must not be empty")
+        #endif
+    }
+    
+    @Test func upToExcludingReturnsNilIfEmpty() async throws {
+        var iterator = AnyReadableSequence("").makeAsyncIterator()
+        #expect(try await iterator.collect(upToExcluding: " " as Character, throwsIfOver: 10) == nil)
     }
     
     @Test func iteratorMapUpToExcluding() async throws {
-        struct LocalError: Error {}
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple "
         
-        let testStream = TestSequence(base: "apple orange banana kiwi kumquat pear pineapple ")
-        
-        let results = testStream.iteratorMap { iterator -> String? in
-            (try await iterator.collect(upToExcluding: " ", throwsIfOver: 100)).map { String($0) }
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: " " as Character, throwsIfOver: 10)).map { String($0) }
         }
         
         var resultsIterator = results.makeAsyncIterator()
@@ -76,5 +183,255 @@ import Testing
         #expect(try await resultsIterator.next() == "kumquat")
         #expect(try await resultsIterator.next() == "pear")
         #expect(try await resultsIterator.next() == "pineapple")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingThrowsIfNotFound() async throws {
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: " " as Character, throwsIfOver: 10)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple")
+        #expect(try await resultsIterator.next() == "orange")
+        #expect(try await resultsIterator.next() == "banana")
+        #expect(try await resultsIterator.next() == "kiwi")
+        #expect(try await resultsIterator.next() == "kumquat")
+        #expect(try await resultsIterator.next() == "pear")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 10, actual: 9)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingThrowsIfTooLong() async throws {
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple apple pen"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: " " as Character, throwsIfOver: 9)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple")
+        #expect(try await resultsIterator.next() == "orange")
+        #expect(try await resultsIterator.next() == "banana")
+        #expect(try await resultsIterator.next() == "kiwi")
+        #expect(try await resultsIterator.next() == "kumquat")
+        #expect(try await resultsIterator.next() == "pear")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 9, actual: 10)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func upToExcludingSequenceReturnsNilIfEmpty() async throws {
+        var iterator = AnyReadableSequence("").makeAsyncIterator()
+        #expect(try await iterator.collect(upToExcluding: ", ", throwsIfOver: 10) == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingSequence() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple, "
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: ", ", throwsIfOver: 17)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange")
+        #expect(try await resultsIterator.next() == "banana kiwi")
+        #expect(try await resultsIterator.next() == "kumquat pear")
+        #expect(try await resultsIterator.next() == "pineapple apple")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingSequenceIfNotFound() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: ", ", throwsIfOver: 17)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange")
+        #expect(try await resultsIterator.next() == "banana kiwi")
+        #expect(try await resultsIterator.next() == "kumquat pear")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 17, actual: 15)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingSequenceIfNotFoundAtBoundary() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: ", ", throwsIfOver: 15)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange")
+        #expect(try await resultsIterator.next() == "banana kiwi")
+        #expect(try await resultsIterator.next() == "kumquat pear")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 15, actual: 15)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapUpToExcludingSequenceIfTooLong() async throws {
+        let inputSequence = "apple orange, banana kiwi, kumquat pear, pineapple apple, "
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            (try await iterator.collect(upToExcluding: ", ", throwsIfOver: 16)).map { String($0) }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple orange")
+        #expect(try await resultsIterator.next() == "banana kiwi")
+        #expect(try await resultsIterator.next() == "kumquat pear")
+        await #expect(throws: AsyncSequenceReaderError.terminationNotFound(maximum: 16, actual: 17)) {
+            try await resultsIterator.next()
+        }
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func trapsIfUpToExcludingTerminationIsEmpty() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            var inputSequence = AnyReadableSequence("").makeAsyncIterator()
+            let _ = try await inputSequence.collect(upToExcluding: "", throwsIfOver: 10)
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToElementsSequence.swift:70: Precondition failed: termination must not be empty")
+        #endif
+    }
+    
+    @Test func iteratorMapTransformingUpToIncluding() async throws {
+        let inputSequence = "apple orange banana kiwi kumquat pear pineapple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            try await iterator.collect(upToIncluding: " " as Character) { sequence -> String in
+                try await sequence.reduce(into: "") { $0.append($1) }
+            }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple ")
+        #expect(try await resultsIterator.next() == "orange ")
+        #expect(try await resultsIterator.next() == "banana ")
+        #expect(try await resultsIterator.next() == "kiwi ")
+        #expect(try await resultsIterator.next() == "kumquat ")
+        #expect(try await resultsIterator.next() == "pear ")
+        #expect(try await resultsIterator.next() == "pineapple")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func iteratorMapTransformingUpToIncludingSequence() async throws {
+        let inputSequence = "apple, orange, banana, kiwi, kumquat, pear, pineapple"
+        
+        let results = inputSequence.iteratorMap { iterator -> String? in
+            try await iterator.collect(upToIncluding: ", ") { sequence -> String in
+                try await sequence.reduce(into: "") { $0.append($1) }
+            }
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "apple, ")
+        #expect(try await resultsIterator.next() == "orange, ")
+        #expect(try await resultsIterator.next() == "banana, ")
+        #expect(try await resultsIterator.next() == "kiwi, ")
+        #expect(try await resultsIterator.next() == "kumquat, ")
+        #expect(try await resultsIterator.next() == "pear, ")
+        #expect(try await resultsIterator.next() == "pineapple")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @Test func trapsIfBufferedIteratorTransformingUpToIncludingTerminationIsEmpty() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            var inputSequence = AsyncBufferedIterator(AnyReadableSequence(" ").makeAsyncIterator())
+            let _ = try await inputSequence.collect(upToIncluding: "") { sequence -> String in
+                try await sequence.reduce(into: "") { $0.append($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToElementsSequence.swift:331: Precondition failed: termination must not be empty")
+        #endif
+    }
+    
+    @Test func rawIteratorTransformingUpToIncluding() async throws {
+        var iterator = AnyReadableSequence("apple orange banana kiwi kumquat pear pineapple").makeAsyncIterator()
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "apple ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "orange ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "banana ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "kiwi ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "kumquat ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "pear ")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "pineapple")
+        #expect(try await iterator.collect(upToIncluding: " " as Character) { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == nil)
+    }
+    
+    @Test func rawIteratorTransformingUpToIncludingSequence() async throws {
+        var iterator = AnyReadableSequence("apple, orange, banana, kiwi, kumquat, pear, pineapple").makeAsyncIterator()
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "apple, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "orange, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "banana, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "kiwi, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "kumquat, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "pear, ")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == "pineapple")
+        #expect(try await iterator.collect(upToIncluding: ", ") { sequence in
+            try await sequence.reduce(into: "") { $0.append($1) }
+        } == nil)
+    }
+    
+    @Test func trapsIfTransformingUpToIncludingTerminationIsEmpty() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            var inputSequence = AnyReadableSequence(" ").makeAsyncIterator()
+            let _ = try await inputSequence.collect(upToIncluding: "") { sequence -> String in
+                try await sequence.reduce(into: "") { $0.append($1) }
+            }
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadUpToElementsSequence.swift:331: Precondition failed: termination must not be empty")
+        #endif
     }
 }

--- a/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderErrorTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderErrorTests.swift
@@ -1,0 +1,37 @@
+//
+//  AsyncSequenceReaderErrorTests.swift
+//  https://github.com/mochidev/AsyncSequenceReader
+//
+//  Created by Dimitri Bouniol on 2026-04-29.
+//  Copyright © 2021-26 Mochi Development, Inc. All rights reserved.
+//  async-sequence-reader-watermark: 7E20A9CAB0604E89B17C6747A34F00C0
+//
+
+@testable import AsyncSequenceReader
+import Testing
+
+@Suite struct AsyncSequenceReaderErrorTests {
+    @Test func descriptions() async throws {
+        #expect(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5).description == "AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5)")
+        #expect(AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5).description == "AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5)")
+    }
+    
+    @Test func equality() async throws {
+        #expect(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) == AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5))
+        #expect(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) != AsyncSequenceReaderError.insufficientElements(minimum: 5, actual: 5))
+        #expect(AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5) == AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5))
+        #expect(AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5) != AsyncSequenceReaderError.terminationNotFound(maximum: 5, actual: 5))
+        #expect(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) != AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5))
+    }
+    
+    @Test func matching() async throws {
+        struct LocalError: Error {}
+        
+        #expect(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) ~= AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5))
+        #expect(!(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) ~= AsyncSequenceReaderError.insufficientElements(minimum: 5, actual: 5)))
+        #expect(AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5) ~= AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5))
+        #expect(!(AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5) ~= AsyncSequenceReaderError.terminationNotFound(maximum: 5, actual: 5)))
+        #expect(!(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) ~= AsyncSequenceReaderError.terminationNotFound(maximum: 0, actual: 5)))
+        #expect(!(AsyncSequenceReaderError.insufficientElements(minimum: 0, actual: 5) ~= LocalError()))
+    }
+}

--- a/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncSequenceReaderTests.swift
@@ -265,4 +265,55 @@ import Testing
             return AsyncSequenceReader(iterator) { await $0.next() }
         }) == nil)
     }
+    
+    @Test func transformDoesNotTrapsForUnreadBufferedStream() async throws {
+        let testStream = AsyncStream<String> { continuation in
+            continuation.yield("A")
+            continuation.finish()
+        }
+        
+        var iterator = AsyncBufferedIterator(testStream.makeAsyncIterator())
+        let result = try await iterator.transform(with: { sequence in
+            return ""
+        }, readSequenceFactory: { iterator in
+            AsyncSequenceReader(iterator) { await $0.next() }
+        })
+        #expect(result == "")
+        #expect(await iterator.next() == "A")
+    }
+    
+    @Test func transformTrapsForUnreadTestSequence() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let testStream = TestSequence(base: ["A"])
+            
+            var iterator = testStream.makeAsyncIterator()
+            let _ = try await iterator.transform(with: { sequence in
+                return ""
+            }, readSequenceFactory: { iterator in
+                AsyncSequenceReader(iterator) { await $0.next() }
+            })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadSequence.swift:39: Precondition failed: A transform was requested, but the sequence was left in a state where the next value will never be read (fix: Use AnyReadableSequence(iterator) instead of calling `.transform` on `iterator` directly)")
+        #endif
+    }
+    
+    @Test func transformTrapsForUnreadEmptyStream() async throws {
+        let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+            let testStream = AsyncStream<String> { continuation in
+                continuation.yield("A")
+                continuation.finish()
+            }
+            
+            var iterator = testStream.makeAsyncIterator()
+            let _ = try await iterator.transform(with: { sequence in
+                return ""
+            }, readSequenceFactory: { iterator in
+                return AsyncSequenceReader(iterator) { await $0.next() }
+            })
+        }
+        #if DEBUG
+        #expect(result?.standardErrorUTF8Lines.first == "AsyncSequenceReader/AsyncReadSequence.swift:39: Precondition failed: A transform was requested, but the sequence was left in a state where the next value will never be read (fix: Use AnyReadableSequence(iterator) instead of calling `.transform` on `iterator` directly)")
+        #endif
+    }
 }

--- a/Tests/AsyncSequenceReaderTests/ExitTest.Result+Lines.swift
+++ b/Tests/AsyncSequenceReaderTests/ExitTest.Result+Lines.swift
@@ -1,0 +1,52 @@
+//
+//  ExitTest.Result+Lines.swift
+//  https://github.com/mochidev/AsyncSequenceReader
+//
+//  Created by Dimitri Bouniol on 2026-04-28.
+//  Copyright © 2021-26 Mochi Development, Inc. All rights reserved.
+//  async-sequence-reader-watermark: 7E20A9CAB0604E89B17C6747A34F00C0
+//
+
+import Testing
+
+extension ExitTest.Result {
+    /// All UTF8-decoded lines written to the standard error stream of the exit test before it exited.
+    ///
+    /// The value of this property may contain any arbitrary sequence of bytes. If you are interested in confirming the raw error content, see ``standardErrorContent`` instead.
+    ///
+    /// When checking the value of this property, keep in mind that the standard output stream is globally accessible, and any code running in an exit test may write to it including the operating system and any third-party dependencies you have declared in your package. Consider comparing the `.last` value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)) in your expectation or requirement:
+    ///
+    /// ```swift
+    /// let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
+    ///     assertionFailure("Oh no")
+    /// }
+    /// #expect(result?.standardErrorUTF8Lines.first == "Ohno.swift:4: Assertion failed: Oh no")
+    /// ```
+    ///
+    /// To enable gathering output from the standard error stream during an exit test, pass `\.standardErrorContent` in the `observedValues` argument of ``expect(processExitsWith:observing:_:sourceLocation:performing:)`` or ``require(processExitsWith:observing:_:sourceLocation:performing:)``.
+    ///
+    /// If you did not request standard error content when running an exit test, the value of this property is the empty array.
+    var standardErrorUTF8Lines: [Substring] {
+        String(decoding: standardErrorContent, as: UTF8.self).split { $0.isNewline }
+    }
+    
+    /// All UTF8-decoded lines written to the standard output stream of the exit test before it exited.
+    ///
+    /// The value of this property may contain any arbitrary sequence of bytes. If you are interested in confirming the raw output content, see ``standardOutputContent`` instead.
+    ///
+    /// When checking the value of this property, keep in mind that the standard output stream is globally accessible, and any code running in an exit test may write to it including the operating system and any third-party dependencies you have declared in your package. Consider comparing the `.last` value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)) in your expectation or requirement:
+    ///
+    /// ```swift
+    /// let result = await #expect(processExitsWith: .success, observing: [\.standardOutputContent]) {
+    ///     print("Oh good")
+    /// }
+    /// #expect(result?.standardOutputUTF8Lines.last == "Oh good")
+    /// ```
+    ///
+    /// To enable gathering output from the standard output stream during an exit test, pass `\.standardOutputContent` in the `observedValues` argument of ``expect(processExitsWith:observing:_:sourceLocation:performing:)`` or ``require(processExitsWith:observing:_:sourceLocation:performing:)``.
+    ///
+    /// If you did not request standard output content when running an exit test, the value of this property is the empty array.
+    var standardOutputUTF8Lines: [Substring] {
+        String(decoding: standardOutputContent, as: UTF8.self).split { $0.isNewline }
+    }
+}

--- a/Tests/AsyncSequenceReaderTests/TestSequence.swift
+++ b/Tests/AsyncSequenceReaderTests/TestSequence.swift
@@ -12,7 +12,7 @@ import Foundation
 struct TestSequence<Base>: AsyncSequence where Base: Sequence {
     typealias Element = Base.Element
     
-    var base: Base
+    nonisolated(unsafe) var base: Base
     
     struct AsyncIterator: AsyncIteratorProtocol {
         var baseIterator: Base.Iterator
@@ -30,7 +30,7 @@ struct TestSequence<Base>: AsyncSequence where Base: Sequence {
 struct ThrowingTestSequence<Base>: AsyncSequence where Base: Sequence {
     typealias Element = Base.Element
     
-    var base: Base
+    nonisolated(unsafe) var base: Base
     
     struct AsyncIterator: AsyncIteratorProtocol {
         var baseIterator: Base.Iterator


### PR DESCRIPTION
- Added iteratorMap() to Sequence for convenience
- Fixed an issue where it was possible to collect from an iterator but never read it causing values to be skipped
- Updated read up to element methods to accept any collection as the termination sequence