### PR TITLE
Iterator Map Typed Throws

### DIFF
--- a/Sources/AsyncSequenceReader/AnyReadableSequence.swift
+++ b/Sources/AsyncSequenceReader/AnyReadableSequence.swift
@@ -24,9 +24,30 @@ public struct AnyReadableSequence<Element, Failure: Error>: AsyncSequence {
         }
         
         @inlinable
-        public mutating func next() async throws(Failure) -> Element? {
-            try await makeUnderlyingNext()
+        @_disfavoredOverload
+        public func next() async throws(Failure) -> Element? {
+            try await next()
         }
+        
+        @inlinable
+        public func next(isolation actor: isolated (any Actor)? = #isolation) async throws(Failure) -> Element? {
+            #if compiler(>=6.2)
+            try await makeUnderlyingNext()
+            #else
+            /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable result type 'Self.Element?' cannot be sent from nonisolated context in call to instance method 'next()'`
+            nonisolated(unsafe) let iterator = self
+            let value = try await iterator._nextSendable()
+            return value as! Element?
+            #endif
+        }
+        
+        #if compiler(<6.2)
+        /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable result type 'Self.Element?' cannot be sent from nonisolated context in call to instance method 'next()'`
+        @usableFromInline
+        func _nextSendable() async throws(Failure) -> sending Any {
+            try await makeUnderlyingNext() as Any
+        }
+        #endif
     }
     
     @inlinable
@@ -41,7 +62,16 @@ public struct AnyReadableSequence<Element, Failure: Error>: AsyncSequence {
     
     /// Initialize ``AnyReadableSequence`` with a sequence.
     @inlinable
-    @_disfavoredOverload
+    public init<S: Sequence & Sendable>(_ sequence: S) where S.Element == Element {
+        self.init {
+            nonisolated(unsafe) var iterator = sequence.makeIterator()
+            
+            return { iterator.next() }
+        }
+    }
+    
+    /// Initialize ``AnyReadableSequence`` with a sequence.
+    @inlinable
     public init<S: Sequence & Sendable>(_ sequence: S) where S.Element == Element, Failure == Never {
         self.init {
             nonisolated(unsafe) var iterator = sequence.makeIterator()
@@ -52,6 +82,7 @@ public struct AnyReadableSequence<Element, Failure: Error>: AsyncSequence {
     
     /// Initialize ``AnyReadableSequence`` with an async sequence.
     @inlinable
+    @_disfavoredOverload
     public init<S: AsyncSequence & Sendable>(_ sequence: S) where S.Element == Element, Failure == any Error {
         self.init {
             nonisolated(unsafe) var iterator = sequence.makeAsyncIterator()

--- a/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
+++ b/Sources/AsyncSequenceReader/AsyncIteratorMapSequence.swift
@@ -38,10 +38,14 @@ extension AsyncSequence {
     ///     }
     ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
     ///
-    /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early.
+    /// - Note: This overload covers when the transformation throws a different (or no) error than the underlying sequence.
+    /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early, as will throwing an error.
     /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
     @inlinable
-    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async -> Transformed) -> AsyncIteratorMapSequence<Self, Transformed> {
+    @_disfavoredOverload
+    public func iteratorMap<Transformed, TransformFailure: Error>(
+        _ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async throws(TransformFailure) -> Transformed
+    ) -> AsyncIteratorMapSequence<Self, Transformed, TransformFailure> {
         AsyncIteratorMapSequence(self, transform: transform)
     }
     
@@ -81,11 +85,15 @@ extension AsyncSequence {
     ///     }
     ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
     ///
+    /// - Note: This overload covers when the transformation throws the same (or no) error than the underlying sequence, but can only be verified on newer distributions of Swift.
     /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early, as will throwing an error.
     /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     @inlinable
-    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async throws -> Transformed) -> AsyncThrowingIteratorMapSequence<Self, Transformed> {
-        AsyncThrowingIteratorMapSequence(self, transform: transform)
+    public func iteratorMap<Transformed>(
+        _ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AsyncIterator>) async throws(Failure) -> Transformed
+    ) -> AsyncIteratorMapSequence<Self, Transformed, Failure> {
+        AsyncIteratorMapSequence(self, transform: transform)
     }
 }
 
@@ -120,69 +128,28 @@ extension Sequence where Self: Sendable {
     ///     }
     ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
     ///
-    /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early.
-    /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
-    @inlinable
-    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AnyReadableSequence<Element, Never>.AsyncIterator>) async -> Transformed) -> AsyncIteratorMapSequence<AnyReadableSequence<Element, Never>, Transformed> {
-        AsyncIteratorMapSequence(AnyReadableSequence(self), transform: transform)
-    }
-    
-    /// Creates an asynchronous sequence that maps the given closure over an iterator for the sequence, which can itself accept multiple reads.
-    ///
-    /// When finished reading from the iterator, return your completed object, and the closure will be called again with an iterator configured to continue where the first one finished.
-    ///
-    /// In this example, an asynchronous sequence of Strings encodes sentences by prefixing each word sequence with a number.
-    /// The number indicates how many words will be read and concatenated into a complete sentence.
-    ///
-    /// The closure provided to the `iteratorMap(_:)` first reads the first available string, interpreting it as a number.
-    /// Then, it will loop the specified number of times, accumulating those words into an array, that is finally assembled into a sentence.
-    ///
-    ///     let dataStream = ... // "2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "1", "Bye!"
-    ///
-    ///     let sentenceStream = dataStream.iteratorMap { iterator -> String? in
-    ///         guard var count = Int(try await iterator.next() ?? "") else {
-    ///             throw SentenceParsing.invalidWordCount
-    ///         }
-    ///
-    ///         var results: [String] = []
-    ///
-    ///         while count > 0, let next = try await iterator.next() {
-    ///             results.append(next)
-    ///             count -= 1
-    ///         }
-    ///
-    ///         guard count == 0 else {
-    ///             throw SentenceParsing.missingFinalWords
-    ///         }
-    ///
-    ///         return results.joined(separator: " ")
-    ///     }
-    ///
-    ///     for try await sentence in sentenceStream {
-    ///         print("\"\(sentence)\"", terminator: ", ")
-    ///     }
-    ///     // Prints: "Hello, World!", "My name is Dimitri.", "", "Bye!"
-    ///
     /// - Parameter transform: A mapping closure. `transform` accepts an iterator representing the original sequence as its parameter and returns a transformed value. Returning `nil` will stop the sequence early, as will throwing an error.
     /// - Returns: An asynchronous sequence that contains, in order, elements produced by the `transform` closure.
     @inlinable
-    public func iteratorMap<Transformed>(_ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AnyReadableSequence<Element, Never>.AsyncIterator>) async throws -> Transformed) -> AsyncThrowingIteratorMapSequence<AnyReadableSequence<Element, Never>, Transformed> {
-        AsyncThrowingIteratorMapSequence(AnyReadableSequence(self), transform: transform)
+    public func iteratorMap<Transformed, TransformFailure: Error>(
+        _ transform: sending @escaping (_ iterator: inout AsyncBufferedIterator<AnyReadableSequence<Element, Never>.AsyncIterator>) async throws(TransformFailure) -> Transformed
+    ) -> AsyncIteratorMapSequence<AnyReadableSequence<Element, Never>, Transformed, TransformFailure> {
+        AsyncIteratorMapSequence(AnyReadableSequence(self), transform: transform)
     }
 }
 
 /// An asynchronous sequence that maps the given closure over the asynchronous sequence’s elements by providing it with the base sequence's iterator to assemble multiple reads into a single transformed object.
-public struct AsyncIteratorMapSequence<Base: AsyncSequence, Transformed> {
+public struct AsyncIteratorMapSequence<Base: AsyncSequence, Transformed, TransformFailure: Error> {
     @usableFromInline
     let base: Base
     
     @usableFromInline
-    nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+    nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws(TransformFailure) -> Transformed
     
     @usableFromInline
     init(
         _ base: Base,
-        transform: @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+        transform: @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws(TransformFailure) -> Transformed
     ) {
         self.base = base
         self.transform = transform
@@ -199,13 +166,17 @@ extension AsyncIteratorMapSequence: AsyncSequence {
     public struct AsyncIterator: AsyncIteratorProtocol {
         @usableFromInline
         var baseIterator: AsyncBufferedIterator<Base.AsyncIterator>
+        
         @usableFromInline
-        nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+        nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws(TransformFailure) -> Transformed
+        
+        @usableFromInline
+        var encounteredError = false
         
         @usableFromInline
         init(
             _ baseIterator: AsyncBufferedIterator<Base.AsyncIterator>,
-            transform: @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async -> Transformed
+            transform: @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async throws(TransformFailure) -> Transformed
         ) {
             self.baseIterator = baseIterator
             self.transform = transform
@@ -213,14 +184,63 @@ extension AsyncIteratorMapSequence: AsyncSequence {
         
         /// Produces the next element in the map sequence.
         ///
-        /// This iterator calls `next()` on its (wrapped) base iterator, and stores the result; if this call returns `nil`, `next()` returns `nil`. Otherwise, `next()` returns the result of calling the transforming closure on the received element.
+        /// This iterator calls `next()` on its (wrapped) base iterator, and stores the result; if this call returns `nil`, `next()` returns `nil`. Otherwise, `next()` returns the result of calling the transforming closure on the received element. If calling the transformation throws an error, the sequence ends and `next()` rethrows the error.
         @inlinable
-        public mutating func next() async rethrows -> Transformed? {
-            guard try await baseIterator.hasMoreData() else {
+        @_disfavoredOverload
+        public mutating func next() async throws -> Transformed? {
+            try await next()
+        }
+        
+        /// Produces the next element in the map sequence.
+        ///
+        /// This iterator calls `next()` on its (wrapped) base iterator, and stores the result; if this call returns `nil`, `next()` returns `nil`. Otherwise, `next()` returns the result of calling the transforming closure on the received element. If calling the transformation throws an error, the sequence ends and `next()` rethrows the error.
+        @inlinable
+        public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async throws -> Transformed? {
+            guard !encounteredError, try await baseIterator.hasMoreData(isolation: actor) else {
                 return nil
             }
-            return await transform(&baseIterator)
+            do {
+                #if compiler(>=6.2)
+                return try await transform(&baseIterator)
+                #else
+                /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable type 'Transformed' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary`
+                nonisolated(unsafe) var iterator = self
+                defer { self = iterator }
+                let value = try await iterator._transformSendable()
+                return value as! Transformed?
+                #endif
+            } catch {
+                encounteredError = true
+                throw error
+            }
         }
+        
+        /// Produces the next element in the map sequence.
+        ///
+        /// This iterator calls `next()` on its (wrapped) base iterator, and stores the result; if this call returns `nil`, `next()` returns `nil`. Otherwise, `next()` returns the result of calling the transforming closure on the received element.
+        @inlinable
+        public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> Transformed? where TransformFailure == Never {
+            guard try await baseIterator.hasMoreData(isolation: actor) else {
+                return nil
+            }
+            #if compiler(>=6.2)
+            return await transform(&baseIterator)
+            #else
+            /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable type 'Transformed' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary`
+            nonisolated(unsafe) var iterator = self
+            defer { self = iterator }
+            let value = await iterator._transformSendable()
+            return value as! Transformed?
+            #endif
+        }
+        
+        #if compiler(<6.2)
+        /// Swift 6.0 and Swift 6.1 require a bypass for `non-sendable type 'Transformed' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary`
+        @usableFromInline
+        mutating func _transformSendable() async throws(TransformFailure) -> sending Any {
+            try await transform(&baseIterator) as Any
+        }
+        #endif
     }
     
     @inlinable
@@ -231,68 +251,3 @@ extension AsyncIteratorMapSequence: AsyncSequence {
 
 extension AsyncIteratorMapSequence: Sendable where Base: Sendable, Transformed: Sendable, Base.Element: Sendable, Base.AsyncIterator: Sendable {}
 extension AsyncIteratorMapSequence.AsyncIterator: Sendable where Base: Sendable, Base.AsyncIterator: Sendable, Transformed: Sendable, Element: Sendable, Base.Element: Sendable {}
-
-public struct AsyncThrowingIteratorMapSequence<Base, Transformed> where Base : AsyncSequence {
-    @usableFromInline
-    let base: Base
-    
-    @usableFromInline
-    nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
-    
-    @usableFromInline
-    init(
-        _ base: Base,
-        transform: @escaping (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
-    ) {
-        self.base = base
-        self.transform = transform
-    }
-}
-
-extension AsyncThrowingIteratorMapSequence: AsyncSequence {
-    public typealias Element = Transformed
-    
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        @usableFromInline
-        var baseIterator: AsyncBufferedIterator<Base.AsyncIterator>
-        
-        @usableFromInline
-        nonisolated(unsafe) let transform: (_ iterator: inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
-        
-        @usableFromInline
-        var encounteredError = false
-        
-        @usableFromInline
-        init(
-            _ baseIterator: AsyncBufferedIterator<Base.AsyncIterator>,
-            transform: @escaping (inout AsyncBufferedIterator<Base.AsyncIterator>) async throws -> Transformed
-        ) {
-            self.baseIterator = baseIterator
-            self.transform = transform
-        }
-        
-        /// Produces the next element in the map sequence.
-        ///
-        /// This iterator calls `next()` on its (wrapped) base iterator, and stores the result; if this call returns `nil`, `next()` returns `nil`. Otherwise, `next()` returns the result of calling the transforming closure on the received element. If calling the closure throws an error, the sequence ends and `next()` rethrows the error.
-        @inlinable
-        public mutating func next() async throws -> Transformed? {
-            guard !encounteredError, try await baseIterator.hasMoreData() else {
-                return nil
-            }
-            do {
-                return try await transform(&baseIterator)
-            } catch {
-                encounteredError = true
-                throw error
-            }
-        }
-    }
-    
-    @inlinable
-    public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(AsyncBufferedIterator(base.makeAsyncIterator()), transform: transform)
-    }
-}
-
-extension AsyncThrowingIteratorMapSequence: Sendable where Base: Sendable, Transformed: Sendable, Base.Element: Sendable, Base.AsyncIterator: Sendable {}
-extension AsyncThrowingIteratorMapSequence.AsyncIterator: Sendable where Base: Sendable, Base.AsyncIterator: Sendable, Transformed: Sendable, Element: Sendable, Base.Element: Sendable {}

--- a/Tests/AsyncSequenceReaderTests/AnyReadableSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AnyReadableSequenceTests.swift
@@ -17,9 +17,20 @@ import Testing
         var iterator = sequence.makeAsyncIterator()
         
         #expect(await iterator.next() == 0)
-        #expect(await iterator.next() == 1)
+        #expect(await iterator.nonIsolatedNext() == 1)
         #expect(await iterator.next() == 2)
         #expect(await iterator.next() == nil)
+    }
+    
+    @Test func castThrowingSequence() async throws {
+        let sequence = AnyReadableSequence<_, any Error>([0, 1, 2])
+        
+        let iterator = sequence.makeAsyncIterator()
+        
+        #expect(try await iterator.next() == 0)
+        #expect(try await iterator.next() == 1)
+        #expect(try await iterator.next() == 2)
+        #expect(try await iterator.next() == nil)
     }
     
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -31,7 +42,7 @@ import Testing
             continuation.finish()
         })
         
-        var iterator = sequence.makeAsyncIterator()
+        let iterator = sequence.makeAsyncIterator()
         
         #expect(await iterator.next() == 0)
         #expect(await iterator.next() == 1)
@@ -39,11 +50,32 @@ import Testing
         #expect(await iterator.next() == nil)
     }
     
-    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     @Test func castThrowingAsyncSequence() async throws {
-        let sequence = AnyReadableSequence(ThrowingTestSequence(base: [0, 1, 2]))
+        let sequence = AnyReadableSequence(ThrowingTestSequence(base: [0, 1, 2]).map({
+            if $0 > 5 {
+                throw CancellationError()
+            }
+            return $0
+        }))
         
-        var iterator = sequence.makeAsyncIterator()
+        let iterator = sequence.makeAsyncIterator()
+        
+        #expect(try await iterator.next() == 0)
+        #expect(try await iterator.next() == 1)
+        #expect(try await iterator.next() == 2)
+        #expect(try await iterator.next() == nil)
+    }
+    
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func castModernThrowingAsyncSequence() async throws {
+        let sequence = AnyReadableSequence(ThrowingTestSequence(base: [0, 1, 2]).map({
+            if $0 > 5 {
+                throw CancellationError()
+            }
+            return $0
+        }))
+        
+        let iterator = sequence.makeAsyncIterator()
         
         #expect(try await iterator.next() == 0)
         #expect(try await iterator.next() == 1)

--- a/Tests/AsyncSequenceReaderTests/AsyncBufferedIteratorTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncBufferedIteratorTests.swift
@@ -10,14 +10,6 @@
 @testable import AsyncSequenceReader
 import Testing
 
-extension AsyncIteratorProtocol {
-    mutating func nonIsolatedNext() async rethrows -> Element? {
-        nonisolated(unsafe) var iterator = self
-        defer { self = iterator }
-        return try await iterator.next()
-    }
-}
-
 @Suite struct AsyncBufferedIteratorTests {
     @Test func bufferIteratorFromStream() async throws {
         let testStream = AsyncStream<Int> { continuation in

--- a/Tests/AsyncSequenceReaderTests/AsyncIteratorMapSequenceTests.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncIteratorMapSequenceTests.swift
@@ -37,7 +37,7 @@ import Testing
         
         #expect(await resultsIterator.next() == "Hello, World!")
         #expect(await resultsIterator.next() == "My name is Dimitri.")
-        #expect(await resultsIterator.next() == "")
+        #expect(try await resultsIterator.nonIsolatedNext() == "")
         #expect(await resultsIterator.next() == "Bye!")
         #expect(await resultsIterator.next() == nil)
     }
@@ -151,6 +151,36 @@ import Testing
             }
             
             return results.joined(separator: " ")
+        }
+        
+        var resultsIterator = results.makeAsyncIterator()
+        
+        #expect(try await resultsIterator.next() == "Hello, World!")
+        #expect(try await resultsIterator.next() == "My name is Dimitri.")
+        #expect(try await resultsIterator.next() == "")
+        #expect(try await resultsIterator.next() == "Bye!")
+        #expect(try await resultsIterator.next() == nil)
+    }
+    
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func modernIteratorMapFromThrowingTestSequence() async throws {
+        let testStream = ThrowingTestSequence(base: ["2", "Hello,", "World!", "4", "My", "name", "is", "Dimitri.", "0", "1", "Bye!"])
+        
+        let results = testStream.iteratorMap { (iterator) async throws(TestSequenceError) -> String? in
+            do {
+                var count = Int(try await iterator.next() ?? "")!
+                
+                var results: [String] = []
+                
+                while count > 0, let next = try await iterator.next() {
+                    results.append(next)
+                    count -= 1
+                }
+                
+                return results.joined(separator: " ")
+            } catch {
+                throw error as! TestSequenceError
+            }
         }
         
         var resultsIterator = results.makeAsyncIterator()

--- a/Tests/AsyncSequenceReaderTests/AsyncIteratorProtocol+NonIsolated.swift
+++ b/Tests/AsyncSequenceReaderTests/AsyncIteratorProtocol+NonIsolated.swift
@@ -1,0 +1,16 @@
+//
+//  AsyncIteratorProtocol+NonIsolated.swift
+//  https://github.com/mochidev/AsyncSequenceReader
+//
+//  Created by Dimitri Bouniol on 2026-05-01.
+//  Copyright © 2021-26 Mochi Development, Inc. All rights reserved.
+//  async-sequence-reader-watermark: 7E20A9CAB0604E89B17C6747A34F00C0
+//
+
+extension AsyncIteratorProtocol {
+    mutating func nonIsolatedNext() async rethrows -> Element? {
+        nonisolated(unsafe) var iterator = self
+        defer { self = iterator }
+        return try await iterator.next()
+    }
+}

--- a/Tests/AsyncSequenceReaderTests/TestSequence.swift
+++ b/Tests/AsyncSequenceReaderTests/TestSequence.swift
@@ -27,16 +27,17 @@ struct TestSequence<Base>: AsyncSequence where Base: Sequence {
     }
 }
 
+struct TestSequenceError: Error {}
+
 struct ThrowingTestSequence<Base>: AsyncSequence where Base: Sequence {
     typealias Element = Base.Element
-    struct LocalError: Error {}
     
     nonisolated(unsafe) var base: Base
     
     struct AsyncIterator: AsyncIteratorProtocol {
         var baseIterator: Base.Iterator
         
-        mutating func next() async throws(LocalError) -> Base.Iterator.Element? {
+        mutating func next() async throws(TestSequenceError) -> Base.Iterator.Element? {
             baseIterator.next()
         }
     }


### PR DESCRIPTION
- Fixed overload issues in `AnyReadableSequence`
- Updated `AsyncIteratorMapSequence` to use typed throws